### PR TITLE
fix: make application load templates from build directory

### DIFF
--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -36,7 +36,7 @@ export const getExpressAppConfig = (directory: string) => (app: express.Applicat
 
   app.set('view engine', 'njk');
     nunjucks.configure([
-      'src/views',
+      'build/views',
       'node_modules/govuk-frontend',
       'node_modules/govuk-frontend/components',
     ], {


### PR DESCRIPTION
### JIRA link

None

### Change description

Loads templates from build directory instead of loading it from source directory. Source directory is not present in released artefact which makes application to crash.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
