### PR TITLE
improvement: separate words with hyphens when building error link

### DIFF
--- a/src/utils/validation/ValidationError.ts
+++ b/src/utils/validation/ValidationError.ts
@@ -1,3 +1,10 @@
+const hyphenise = (value: string): string => {
+    return value
+        .replace(/([a-z\d])([A-Z])/g, '$1-$2')
+        .replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1-$2')
+        .toLowerCase();
+};
+
 export class ValidationError {
     constructor (public readonly field: string, public readonly text: string) {
         if (!field) {
@@ -9,6 +16,6 @@ export class ValidationError {
     }
 
     get href(): string {
-        return `#${this.field}-error`;
+        return `#${hyphenise(this.field)}-error`;
     }
 }

--- a/src/views/penalty-details.njk
+++ b/src/views/penalty-details.njk
@@ -32,7 +32,7 @@
             },
             errorMessage: validationResult.getErrorForField("companyNumber") if validationResult,
             classes: "govuk-input--company-number",
-            id: "companyNumber",
+            id: "company-number",
             name: "companyNumber",
             value: companyNumber,
             autocomplete: "off"
@@ -48,7 +48,7 @@
             },
             errorMessage: validationResult.getErrorForField("penaltyReference") if validationResult,
             classes: "govuk-input--penalty-reference",
-            id: "penaltyReference",
+            id: "penalty-reference",
             name: "penaltyReference",
             value: penaltyReference,
             autocomplete: "off"

--- a/test/utils/validation/ValidationError.test.ts
+++ b/test/utils/validation/ValidationError.test.ts
@@ -18,8 +18,18 @@ describe('ValidationError', () => {
     });
 
     describe('link building', () => {
-        it(`should prepend field name with '#' and append '-error' to field name`, () => {
+        it('should prepend field name with "#" and append "-error" to field name', () => {
             expect(new ValidationError('field', 'Unexpected error').href).to.be.equal('#field-error');
         });
+
+        it('should hyphenise field name when it is camel cased', () => {
+            expect(new ValidationError('longerField', 'Unexpected error').href).to.be.equal('#longer-field-error');
+            expect(new ValidationError('evenLongerField', 'Unexpected error').href).to.be.equal('#even-longer-field-error');
+            expect(new ValidationError('TheLongestField', 'Unexpected error').href).to.be.equal('#the-longest-field-error');
+        });
+
+        it('should not hyphenise field name when it is already hyphenised', () => {
+            expect(new ValidationError('longer-field', 'Unexpected error').href).to.be.equal('#longer-field-error');
+        })
     });
 });


### PR DESCRIPTION
### JIRA link

None

### Change description

Converts camel cased field names into hyphen separated words when building error href

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
