### PR TITLE
refactor: serve application from '/appeal-a-penalty' path

### DIFF
--- a/src/controllers/EntryController.ts
+++ b/src/controllers/EntryController.ts
@@ -1,12 +1,11 @@
-import { Request, Response, NextFunction } from 'express';
 import { controller, httpGet, BaseHttpController } from 'inversify-express-utils';
-import { PENALTY_DETAILS_PREFIX, ENTRY_URI } from '../utils/Paths';
+import { PENALTY_DETAILS_PAGE_URI, ENTRY_PAGE_URI } from '../utils/Paths';
 
-@controller(ENTRY_URI)
+@controller(ENTRY_PAGE_URI)
 export class EntryController extends BaseHttpController{
 
     @httpGet('')
     public redirectView(): void {
-        this.httpContext.response.redirect(PENALTY_DETAILS_PREFIX);
+        this.httpContext.response.redirect(PENALTY_DETAILS_PAGE_URI);
     }
 }

--- a/src/controllers/HealthCheckController.ts
+++ b/src/controllers/HealthCheckController.ts
@@ -2,8 +2,9 @@ import { inject } from 'inversify';
 import { BaseHttpController, httpGet, controller } from 'inversify-express-utils';
 import { RedisService } from '../services/RedisService';
 import { OK, INTERNAL_SERVER_ERROR } from 'http-status-codes';
+import { HEALTH_CHECK_URI } from '../utils/Paths';
 
-@controller('/healthCheck')
+@controller(HEALTH_CHECK_URI)
 export class HealthCheckController extends BaseHttpController {
 
     constructor(@inject(RedisService) private readonly redisService: RedisService) {

--- a/src/controllers/LandingController.ts
+++ b/src/controllers/LandingController.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { controller, httpGet, httpPost, BaseHttpController } from 'inversify-express-utils';
-import { ENTRY_PAGE_URI } from '../utils/Paths';
+import { LANDING_PAGE_URI, ENTRY_PAGE_URI } from '../utils/Paths';
 
-@controller('/')
+@controller(LANDING_PAGE_URI)
 export class LandingController extends BaseHttpController {
 
     @httpGet('')

--- a/src/controllers/LandingController.ts
+++ b/src/controllers/LandingController.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { controller, httpGet, httpPost, BaseHttpController } from 'inversify-express-utils';
-import { PENALTY_DETAILS_PREFIX, ENTRY_URI } from '../utils/Paths';
+import { ENTRY_PAGE_URI } from '../utils/Paths';
 
 @controller('/')
 export class LandingController extends BaseHttpController {
@@ -12,6 +12,6 @@ export class LandingController extends BaseHttpController {
 
     @httpPost('')
     public continue(): void {
-        this.httpContext.response.redirect(ENTRY_URI);
+        this.httpContext.response.redirect(ENTRY_PAGE_URI);
     }
 }

--- a/src/controllers/LandingController.ts
+++ b/src/controllers/LandingController.ts
@@ -1,8 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { controller, httpGet, httpPost, BaseHttpController } from 'inversify-express-utils';
-import { LANDING_PAGE_URI, ENTRY_PAGE_URI } from '../utils/Paths';
+import { ROOT_URI, ENTRY_PAGE_URI } from '../utils/Paths';
 
-@controller(LANDING_PAGE_URI)
+@controller(ROOT_URI)
 export class LandingController extends BaseHttpController {
 
     @httpGet('')

--- a/src/controllers/PenaltyDetailsController.ts
+++ b/src/controllers/PenaltyDetailsController.ts
@@ -1,7 +1,7 @@
 import { controller, httpGet, httpPost } from 'inversify-express-utils';
 import { inject } from 'inversify';
 import { UNPROCESSABLE_ENTITY } from 'http-status-codes';
-import { PENALTY_DETAILS_PREFIX, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../utils/Paths';
+import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../utils/Paths';
 import { BaseAsyncHttpController } from './BaseAsyncHttpController';
 import { ValidationResult } from '../utils/validation/ValidationResult';
 import { sanitize } from '../utils/CompanyNumberSanitizer';
@@ -11,7 +11,7 @@ import { PenaltyReferenceDetails } from '../models/PenaltyReferenceDetails';
 import { schema } from '../models/PenaltyReferenceDetails.schema';
 
 
-@controller(PENALTY_DETAILS_PREFIX)
+@controller(PENALTY_DETAILS_PAGE_URI)
 export class PenaltyDetailsController extends BaseAsyncHttpController {
 
     private COMPANY_NUMBER: string = 'companyNumber';

--- a/src/public/sass/application.scss
+++ b/src/public/sass/application.scss
@@ -1,3 +1,4 @@
+$govuk-assets-path: '/appeal-a-penalty/';
 $govuk-global-styles: true;
 
 @import 'govuk-frontend/govuk/all';

--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -5,6 +5,7 @@ import * as nunjucks from 'nunjucks';
 import bodyParser = require('body-parser');
 import cookieParser = require('cookie-parser');
 import { handler } from '../middleware/ErrorHandler';
+import { ROOT_URI } from './Paths';
 
 const DEFAULT_ENV_FILE = `${__dirname}/../../.env`;
 
@@ -22,11 +23,10 @@ export const loadEnvironmentVariablesFromFiles = () => {
 };
 
 export const getExpressAppConfig = (directory: string) => (app: express.Application): void => {
-
-  app.use(express.static(path.join(directory, '/public')));
-  app.use(express.static(path.join(directory, '/node_modules/govuk-frontend')));
-  app.use(express.static(path.join(directory, '/node_modules/govuk-frontend/govuk')));
-  app.use(express.static(path.join(directory, '/node_modules/govuk-frontend/govuk/assets')));
+  app.use(ROOT_URI, express.static(path.join(directory, '/public')));
+  app.use(ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend')));
+  app.use(ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend/govuk')));
+  app.use(ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend/govuk/assets')));
 
   app.use(handler);
 
@@ -43,5 +43,7 @@ export const getExpressAppConfig = (directory: string) => (app: express.Applicat
       autoescape: true,
       express: app,
     });
+
+    app.locals.ROOT_URI = ROOT_URI;
 };
 

--- a/src/utils/Paths.ts
+++ b/src/utils/Paths.ts
@@ -1,14 +1,14 @@
-const ROOT = '/appeal-a-penalty';
+export const ROOT_URI = '/appeal-a-penalty';
+
 const CATEGORY_PREFIXES = {
-    OTHER_REASON: `${ROOT}/other`
+    OTHER_REASON: `${ROOT_URI}/other`
 };
 
 // Endpoints
-export const HEALTH_CHECK_URI = `${ROOT}/healthcheck`;
+export const HEALTH_CHECK_URI = `${ROOT_URI}/healthcheck`;
 
 // Pages
-export const LANDING_PAGE_URI = `${ROOT}`;
-export const ENTRY_PAGE_URI = `${ROOT}/start`;
-export const PENALTY_DETAILS_PAGE_URI = `${ROOT}/penalty-reference`;
+export const ENTRY_PAGE_URI = `${ROOT_URI}/start`;
+export const PENALTY_DETAILS_PAGE_URI = `${ROOT_URI}/penalty-reference`;
 export const OTHER_REASON_DISCLAIMER_PAGE_URI = `${CATEGORY_PREFIXES.OTHER_REASON}/other-reason-entry`;
 export const OTHER_REASON_PAGE_URI = `${CATEGORY_PREFIXES.OTHER_REASON}/reason-other`;

--- a/src/utils/Paths.ts
+++ b/src/utils/Paths.ts
@@ -3,6 +3,11 @@ const CATEGORY_PREFIXES = {
     OTHER_REASON: `${ROOT}/other`
 };
 
+// Endpoints
+export const HEALTH_CHECK_URI = `${ROOT}/healthcheck`;
+
+// Pages
+export const LANDING_PAGE_URI = `${ROOT}`;
 export const ENTRY_PAGE_URI = `${ROOT}/start`;
 export const PENALTY_DETAILS_PAGE_URI = `${ROOT}/penalty-reference`;
 export const OTHER_REASON_DISCLAIMER_PAGE_URI = `${CATEGORY_PREFIXES.OTHER_REASON}/other-reason-entry`;

--- a/src/utils/Paths.ts
+++ b/src/utils/Paths.ts
@@ -1,12 +1,9 @@
-export const ROOT = '';
+const ROOT = '/appeal-a-penalty';
+const CATEGORY_PREFIXES = {
+    OTHER_REASON: `${ROOT}/other`
+};
 
-export const ENTRY_URI = `${ROOT}/start`;
-
-export const PENALTY_DETAILS_PREFIX=`${ROOT}/penalty-reference`;
-
-export const OTHER_REASON_CATEGORY_PREFIX = `${ROOT}/other`;
-
-export const OTHER_REASON_DISCLAIMER_PAGE_PREFIX = '/other-reason-entry';
-export const OTHER_REASON_DISCLAIMER_PAGE_URI = `${OTHER_REASON_CATEGORY_PREFIX}${OTHER_REASON_DISCLAIMER_PAGE_PREFIX}`;
-
-export const OTHER_REASON_PAGE_URI = `${OTHER_REASON_CATEGORY_PREFIX}/reason-other`;
+export const ENTRY_PAGE_URI = `${ROOT}/start`;
+export const PENALTY_DETAILS_PAGE_URI = `${ROOT}/penalty-reference`;
+export const OTHER_REASON_DISCLAIMER_PAGE_URI = `${CATEGORY_PREFIXES.OTHER_REASON}/other-reason-entry`;
+export const OTHER_REASON_PAGE_URI = `${CATEGORY_PREFIXES.OTHER_REASON}/reason-other`;

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -8,7 +8,7 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-  <link href="/css/application.css" rel="stylesheet"/>
+  <link href="{{ ROOT_URI }}/css/application.css" rel="stylesheet"/>
   <!--<![endif]-->
 
   <script src="https://code.jquery.com/jquery-1.12.4.min.js"
@@ -21,9 +21,9 @@
 {% block header %}
   {{
     govukHeader({
-      homepageUrl: "/appeals",
+      homepageUrl: ROOT_URI,
       serviceName: serviceName,
-      serviceUrl: "/appeals",
+      serviceUrl: ROOT_URI,
       containerClasses: "govuk-width-container"
     })
   }}
@@ -71,6 +71,6 @@
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="/govuk/all.js"></script>
+  <script src="{{ ROOT_URI }}/govuk/all.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/test/controllers/EntryController.test.ts
+++ b/test/controllers/EntryController.test.ts
@@ -5,7 +5,7 @@ import * as request from 'supertest'
 import { RedisService } from '../../src/services/RedisService';
 import { createSubstituteOf } from '../SubstituteFactory';
 import { MOVED_TEMPORARILY  } from 'http-status-codes';
-import { ENTRY_URI, PENALTY_DETAILS_PREFIX} from '../../src/utils/Paths';
+import { ENTRY_PAGE_URI, PENALTY_DETAILS_PREFIX} from '../../src/utils/Paths';
 import { expect } from 'chai';
 
 describe('EntryController', () => {
@@ -15,7 +15,7 @@ describe('EntryController', () => {
             const app = createApplication(container => {
                 container.bind(RedisService).toConstantValue(createSubstituteOf<RedisService>());
             });
-            await request(app).get(ENTRY_URI).expect(response => {
+            await request(app).get(ENTRY_PAGE_URI).expect(response => {
                 expect(response.status).to.be.equal(MOVED_TEMPORARILY);
                 expect(response.get('Location')).to.be.equal(PENALTY_DETAILS_PREFIX);
             });

--- a/test/controllers/EntryController.test.ts
+++ b/test/controllers/EntryController.test.ts
@@ -5,7 +5,7 @@ import * as request from 'supertest'
 import { RedisService } from '../../src/services/RedisService';
 import { createSubstituteOf } from '../SubstituteFactory';
 import { MOVED_TEMPORARILY  } from 'http-status-codes';
-import { ENTRY_PAGE_URI, PENALTY_DETAILS_PREFIX} from '../../src/utils/Paths';
+import { ENTRY_PAGE_URI, PENALTY_DETAILS_PAGE_URI } from '../../src/utils/Paths';
 import { expect } from 'chai';
 
 describe('EntryController', () => {
@@ -17,7 +17,7 @@ describe('EntryController', () => {
             });
             await request(app).get(ENTRY_PAGE_URI).expect(response => {
                 expect(response.status).to.be.equal(MOVED_TEMPORARILY);
-                expect(response.get('Location')).to.be.equal(PENALTY_DETAILS_PREFIX);
+                expect(response.get('Location')).to.be.equal(PENALTY_DETAILS_PAGE_URI);
             });
         });
     });

--- a/test/controllers/HealthCheckController.test.ts
+++ b/test/controllers/HealthCheckController.test.ts
@@ -6,6 +6,7 @@ import { createSubstituteOf } from '../SubstituteFactory';
 
 import '../../src/controllers/HealthCheckController'
 import { RedisService } from '../../src/services/RedisService';
+import { HEALTH_CHECK_URI } from '../../src/utils/Paths';
 
 describe('HealthCheckController', () => {
     it('should return 200 with status when redis database is up', async () => {
@@ -30,6 +31,6 @@ describe('HealthCheckController', () => {
 
     function makeHealthCheckRequest(app: Application): request.Test {
         return request(app)
-            .get('/healthcheck');
+            .get(HEALTH_CHECK_URI);
     }
 });

--- a/test/controllers/PenaltyDetailsController.test.ts
+++ b/test/controllers/PenaltyDetailsController.test.ts
@@ -8,7 +8,7 @@ import { RedisService } from '../../src/services/RedisService';
 import { MOVED_TEMPORARILY, OK, UNPROCESSABLE_ENTITY } from 'http-status-codes';
 import { expect } from 'chai';
 import { PenaltyReferenceDetails } from '../../src/models/PenaltyReferenceDetails';
-import { PENALTY_DETAILS_PREFIX, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../../src/utils/Paths'
+import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../../src/utils/Paths'
 
 const pageHeading = 'What are the penalty details?';
 const errorSummaryHeading = 'There is a problem with the information you entered';
@@ -21,7 +21,7 @@ describe('PenaltyDetailsController', () => {
     describe('GET request', () => {
 
         it('should return 200 when trying to access page without a session', async () => {
-            await request(app).get(PENALTY_DETAILS_PREFIX)
+            await request(app).get(PENALTY_DETAILS_PAGE_URI)
                 .expect(response => {
                     expect(response.status).to.be.equal(OK);
                     expect(response.text).to.contain(pageHeading)
@@ -41,7 +41,7 @@ describe('PenaltyDetailsController', () => {
                 }));
             });
 
-            await request(app).get(PENALTY_DETAILS_PREFIX)
+            await request(app).get(PENALTY_DETAILS_PAGE_URI)
                 .set('Cookie', ['penalty-cookie=1'])
                 .expect(response => {
                     expect(response.status).to.be.equal(OK);
@@ -66,7 +66,7 @@ describe('PenaltyDetailsController', () => {
                 }));
             });
 
-            await request(app).post(PENALTY_DETAILS_PREFIX)
+            await request(app).post(PENALTY_DETAILS_PAGE_URI)
                 .send(penaltyDetails)
                 .expect(response => {
                     expect(response.status).to.be.equal(MOVED_TEMPORARILY);
@@ -81,7 +81,7 @@ describe('PenaltyDetailsController', () => {
                 companyNumber: 'SC123123'
             };
 
-            await request(app).post(PENALTY_DETAILS_PREFIX)
+            await request(app).post(PENALTY_DETAILS_PAGE_URI)
                 .send(penaltyDetails)
                 .expect(response => {
                     expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
@@ -96,7 +96,7 @@ describe('PenaltyDetailsController', () => {
                 companyNumber: 'SC123123'
             };
 
-            await request(app).post(PENALTY_DETAILS_PREFIX)
+            await request(app).post(PENALTY_DETAILS_PAGE_URI)
                 .send(penaltyDetails)
                 .expect(response => {
                     expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
@@ -111,7 +111,7 @@ describe('PenaltyDetailsController', () => {
                 companyNumber: ''
             };
 
-            await request(app).post(PENALTY_DETAILS_PREFIX)
+            await request(app).post(PENALTY_DETAILS_PAGE_URI)
                 .send(penaltyDetails)
                 .expect(response => {
                     expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
@@ -126,7 +126,7 @@ describe('PenaltyDetailsController', () => {
                 companyNumber: 'AB66666666'
             };
 
-            await request(app).post(PENALTY_DETAILS_PREFIX)
+            await request(app).post(PENALTY_DETAILS_PAGE_URI)
                 .send(penaltyDetails)
                 .expect(response => {
                     expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);


### PR DESCRIPTION
### JIRA link

None

### Change description

Serve application from '/appeal-a-penalty' path.

Note: It does not use internal CDN at this point. It needs to be explored further and introduced later if needed.

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
