### PR TITLE
refactor: substitute double for single quotation in templates

### DIFF
--- a/src/views/landing.njk
+++ b/src/views/landing.njk
@@ -20,12 +20,12 @@
 {% endblock %}
 
 {% block content%}
-  <div class='govuk-grid-row'>
-    <div class='govuk-grid-column-two-thirds'>
-      <h1 class='govuk-heading-xl'>{{ serviceName }}</h1>
-      <p class='govuk-body-l'>Use this service to appeal a penalty issued to a company for not filing its annual accounts on time.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ serviceName }}</h1>
+      <p class="govuk-body-l">Use this service to appeal a penalty issued to a company for not filing its annual accounts on time.</p>
       <p>It may take up to 30 minutes to complete this application.</p>
-      <form method='post'>
+      <form method="post">
         {{ 
           govukButton({
             text: 'Start now',
@@ -36,12 +36,12 @@
           }) 
         }}
       </form>
-      <h2 class='govuk-heading-m'>Before you start</h2>
+      <h2 class="govuk-heading-m">Before you start</h2>
       <p>
-        <a href='https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#appealing' target='_blank'>Read the guidance on appealing a penalty.</a>
+        <a href="https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#appealing" target="_blank">Read the guidance on appealing a penalty.</a>
       </p>
-      <h3 class='govuk-heading-s'>You’ll need:</h3>
-      <ul class='govuk-list govuk-list--bullet'>
+      <h3 class="govuk-heading-s">You’ll need:</h3>
+      <ul class="govuk-list govuk-list--bullet">
         <li>the company number</li>
         <li>the company authentication code for online filing</li>
         <li>the penalty reference</li>
@@ -49,27 +49,27 @@
         <li>documents that support the reason for the appeal (optional)</li>
       </ul>
     </div>
-    <div class='govuk-grid-column-one-third'>
-      <aside class='app-related-items' role='complementary'>
-        <h2 class='govuk-heading-m' id='subsection-title'>
+    <div class="govuk-grid-column-one-third">
+      <aside class="app-related-items" role="complementary">
+        <h2 class="govuk-heading-m" id="subsection-title">
           Related content
         </h2>
-        <nav role='navigation' aria-labelledby='subsection-title'>
-          <ul class='govuk-list govuk-body-s'>
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list govuk-body-s">
             <li>
-              <a href='https://www.gov.uk/file-an-annual-return-with-companies-house'>
+              <a href="https://www.gov.uk/file-an-annual-return-with-companies-house">
                 File your confirmation statement (annual return) with Companies House
               </a>
             </li>
             <li>
-              <a href='https://www.gov.uk/running-a-limited-company'>
+              <a href="https://www.gov.uk/running-a-limited-company">
                 Running a limited company
               </a>
             </li>
             <li>
-              <a href='https://www.gov.uk/browse/business/limited-company' class='govuk-!-w-bold'>
+              <a href="https://www.gov.uk/browse/business/limited-company" class="govuk-!-w-bold">
                 More
-                <span class='visuallyhidden'>Running a limited company</span>
+                <span class="visuallyhidden">Running a limited company</span>
               </a>
             </li>
           </ul>

--- a/src/views/landing.njk
+++ b/src/views/landing.njk
@@ -1,7 +1,7 @@
-{% extends "layout.njk" %}
+{% extends 'layout.njk' %}
 
-{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "govuk/components/button/macro.njk"      import govukButton %}
+{% from 'govuk/components/breadcrumbs/macro.njk' import govukBreadcrumbs %}
+{% from 'govuk/components/button/macro.njk'      import govukButton %}
 
 {% block pageTitle %}
   {{ serviceName }}
@@ -20,28 +20,28 @@
 {% endblock %}
 
 {% block content%}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">{{ serviceName }}</h1>
-      <p class="govuk-body-l">Use this service to appeal a penalty issued to a company for not filing its annual accounts on time.</p>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
+      <h1 class='govuk-heading-xl'>{{ serviceName }}</h1>
+      <p class='govuk-body-l'>Use this service to appeal a penalty issued to a company for not filing its annual accounts on time.</p>
       <p>It may take up to 30 minutes to complete this application.</p>
-      <form method="post">
+      <form method='post'>
         {{ 
           govukButton({
-            text: "Start now",
+            text: 'Start now',
             isStartButton: true,
             attributes: {
-              id: "submit"
+              id: 'submit'
             }
           }) 
         }}
       </form>
-      <h2 class="govuk-heading-m">Before you start</h2>
+      <h2 class='govuk-heading-m'>Before you start</h2>
       <p>
-        <a href="https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#appealing" target="_blank">Read the guidance on appealing a penalty.</a>
+        <a href='https://www.gov.uk/government/publications/late-filing-penalties/late-filing-penalties#appealing' target='_blank'>Read the guidance on appealing a penalty.</a>
       </p>
-      <h3 class="govuk-heading-s">You’ll need:</h3>
-      <ul class="govuk-list govuk-list--bullet">
+      <h3 class='govuk-heading-s'>You’ll need:</h3>
+      <ul class='govuk-list govuk-list--bullet'>
         <li>the company number</li>
         <li>the company authentication code for online filing</li>
         <li>the penalty reference</li>
@@ -49,27 +49,27 @@
         <li>documents that support the reason for the appeal (optional)</li>
       </ul>
     </div>
-    <div class="govuk-grid-column-one-third">
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">
+    <div class='govuk-grid-column-one-third'>
+      <aside class='app-related-items' role='complementary'>
+        <h2 class='govuk-heading-m' id='subsection-title'>
           Related content
         </h2>
-        <nav role="navigation" aria-labelledby="subsection-title">
-          <ul class="govuk-list govuk-body-s">
+        <nav role='navigation' aria-labelledby='subsection-title'>
+          <ul class='govuk-list govuk-body-s'>
             <li>
-              <a href="https://www.gov.uk/file-an-annual-return-with-companies-house">
+              <a href='https://www.gov.uk/file-an-annual-return-with-companies-house'>
                 File your confirmation statement (annual return) with Companies House
               </a>
             </li>
             <li>
-              <a href="https://www.gov.uk/running-a-limited-company">
+              <a href='https://www.gov.uk/running-a-limited-company'>
                 Running a limited company
               </a>
             </li>
             <li>
-              <a href="https://www.gov.uk/browse/business/limited-company" class="govuk-!-w-bold">
+              <a href='https://www.gov.uk/browse/business/limited-company' class='govuk-!-w-bold'>
                 More
-                <span class="visuallyhidden">Running a limited company</span>
+                <span class='visuallyhidden'>Running a limited company</span>
               </a>
             </li>
           </ul>

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -8,12 +8,12 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-  <link href='{{ ROOT_URI }}/css/application.css' rel='stylesheet'/>
+  <link href="{{ ROOT_URI }}/css/application.css" rel="stylesheet"/>
   <!--<![endif]-->
 
-  <script src='https://code.jquery.com/jquery-1.12.4.min.js'
-          integrity='sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ='
-          crossorigin='anonymous'></script>
+  <script src="https://code.jquery.com/jquery-1.12.4.min.js"
+          integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+          crossorigin="anonymous"></script>
 
   {% block download %}{% endblock %}
 {% endblock %}
@@ -71,6 +71,6 @@
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src='{{ ROOT_URI }}/govuk/all.js'></script>
+  <script src="{{ ROOT_URI }}/govuk/all.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -1,19 +1,19 @@
-{% extends "govuk/template.njk" %}
+{% extends 'govuk/template.njk' %}
 
-{% from "govuk/components/footer/macro.njk"       import govukFooter %}
-{% from "govuk/components/header/macro.njk"       import govukHeader %}
-{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from 'govuk/components/footer/macro.njk'       import govukFooter %}
+{% from 'govuk/components/header/macro.njk'       import govukHeader %}
+{% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
 
-{% set serviceName = "Appeal a late filing penalty" %}
+{% set serviceName = 'Appeal a late filing penalty' %}
 
 {% block head %}
   <!--[if !IE 8]><!-->
-  <link href="{{ ROOT_URI }}/css/application.css" rel="stylesheet"/>
+  <link href='{{ ROOT_URI }}/css/application.css' rel='stylesheet'/>
   <!--<![endif]-->
 
-  <script src="https://code.jquery.com/jquery-1.12.4.min.js"
-          integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
-          crossorigin="anonymous"></script>
+  <script src='https://code.jquery.com/jquery-1.12.4.min.js'
+          integrity='sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ='
+          crossorigin='anonymous'></script>
 
   {% block download %}{% endblock %}
 {% endblock %}
@@ -24,18 +24,18 @@
       homepageUrl: ROOT_URI,
       serviceName: serviceName,
       serviceUrl: ROOT_URI,
-      containerClasses: "govuk-width-container"
+      containerClasses: 'govuk-width-container'
     })
   }}
 {% endblock %}
 
-{% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
+{% set mainClasses = mainClasses | default('govuk-main-wrapper--auto-spacing') %}
 
 {% block beforeContent %}
   {{
     govukPhaseBanner({
       tag: {
-        text: "Beta"
+        text: 'Beta'
       }
     })
   }}
@@ -48,20 +48,20 @@
       meta: {
         items: [
           {
-            href: "http://resources.companieshouse.gov.uk/legal/termsAndConditions.shtml",
-            text: "Policies"
+            href: 'http://resources.companieshouse.gov.uk/legal/termsAndConditions.shtml',
+            text: 'Policies'
           },
           {
-            href: "https://www.gov.uk/help/cookies",
-            text: "Cookies"
+            href: 'https://www.gov.uk/help/cookies',
+            text: 'Cookies'
           },
           {
-            href: "https://www.gov.uk/contact",
-            text: "Contact us"
+            href: 'https://www.gov.uk/contact',
+            text: 'Contact us'
           },
           {
-            href: "https://developer.companieshouse.gov.uk/",
-            text: "Developers"
+            href: 'https://developer.companieshouse.gov.uk/',
+            text: 'Developers'
           }
         ]
       }
@@ -71,6 +71,6 @@
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
-  <script src="{{ ROOT_URI }}/govuk/all.js"></script>
+  <script src='{{ ROOT_URI }}/govuk/all.js'></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/src/views/other-reason-disclaimer.njk
+++ b/src/views/other-reason-disclaimer.njk
@@ -1,34 +1,19 @@
-{% extends "layout.njk" %}
+{% extends 'layout.njk' %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
+{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 
 {% block pageTitle %}
   Unlikely appeal examples
 {% endblock %}
-{% block beforeContent %}
-  {{ 
-    govukPhaseBanner({
-      tag: {
-        text: "alpha"
-      },
-      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-    }) 
-  }}
-  {{ 
-    govukBackLink({
-      text: "Back",
-      href: "../"
-    }) 
-  }}
-{% endblock %}
+
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <div class="interruption-card">
-        <h1 class="govuk-heading-xl">Before you continue</h1>
-        <p class="govuk-body-l">We may reject your appeal if you tell us:</p>
-        <ul class="govuk-list govuk-list--bullet">
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-full'>
+      <div class='interruption-card'>
+        <h1 class='govuk-heading-xl'>Before you continue</h1>
+        <p class='govuk-body-l'>We may reject your appeal if you tell us:</p>
+        <ul class='govuk-list govuk-list--bullet'>
 
           <li>there is a problem with your accountant</li>
           <li>your company is dormant</li>
@@ -38,13 +23,13 @@
           <li>the directors live or were travelling overseas</li>
           <li>another director is responsible for preparing the accounts</li>
         </ul>
-        <form method="post">
+        <form method='post'>
           {{ 
             govukButton({
-              text: "Continue with appeal",
-              classes: "govuk-link govuk-!-margin-top-5 govuk-link--interrupt",
+              text: 'Continue with appeal',
+              classes: 'govuk-link govuk-!-margin-top-5 govuk-link--interrupt',
               attributes: {
-                id: "submit"
+                id: 'submit'
               }
             }) 
           }}

--- a/src/views/other-reason-disclaimer.njk
+++ b/src/views/other-reason-disclaimer.njk
@@ -7,12 +7,12 @@
 {% endblock %}
 
 {% block content %}
-  <div class='govuk-grid-row'>
-    <div class='govuk-grid-column-full'>
-      <div class='interruption-card'>
-        <h1 class='govuk-heading-xl'>Before you continue</h1>
-        <p class='govuk-body-l'>We may reject your appeal if you tell us:</p>
-        <ul class='govuk-list govuk-list--bullet'>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="interruption-card">
+        <h1 class="govuk-heading-xl">Before you continue</h1>
+        <p class="govuk-body-l">We may reject your appeal if you tell us:</p>
+        <ul class="govuk-list govuk-list--bullet">
 
           <li>there is a problem with your accountant</li>
           <li>your company is dormant</li>
@@ -22,7 +22,7 @@
           <li>the directors live or were travelling overseas</li>
           <li>another director is responsible for preparing the accounts</li>
         </ul>
-        <form method='post'>
+        <form method="post">
           {{ 
             govukButton({
               text: 'Continue with appeal',

--- a/src/views/other-reason-disclaimer.njk
+++ b/src/views/other-reason-disclaimer.njk
@@ -1,7 +1,6 @@
 {% extends 'layout.njk' %}
 
 {% from 'govuk/components/button/macro.njk' import govukButton %}
-{% from 'govuk/components/back-link/macro.njk' import govukBackLink %}
 
 {% block pageTitle %}
   Unlikely appeal examples

--- a/src/views/other-reason.njk
+++ b/src/views/other-reason.njk
@@ -10,8 +10,8 @@
 {% endblock %}
 
 {% block content %}
-  <div class='govuk-grid-row'>
-    <div class='govuk-grid-column-two-thirds'>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       {{
         govukErrorSummary({
           titleText: 'There is a problem with the information you entered',
@@ -19,9 +19,9 @@
         }) if validationResult and validationResult.errors.length > 0
       }}
 
-      <form method='post'>
-        <h1 class='govuk-heading-xl'>Tell us why you’re appealing this penalty</h1>
-        <p class='govuk-body-l'>Anything you tell us to support your appeal will be kept confidential.</p>
+      <form method="post">
+        <h1 class="govuk-heading-xl">Tell us why you’re appealing this penalty</h1>
+        <p class="govuk-body-l">Anything you tell us to support your appeal will be kept confidential.</p>
 
         {{
           govukInput({

--- a/src/views/other-reason.njk
+++ b/src/views/other-reason.njk
@@ -1,17 +1,17 @@
-{% extends "layout.njk" %}
+{% extends 'layout.njk' %}
 
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/input/macro.njk' import govukInput %}
+{% from 'govuk/components/textarea/macro.njk' import govukTextarea %}
+{% from 'govuk/components/button/macro.njk' import govukButton %}
 
 {% block pageTitle %}
   Appealing for other reasons
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
       {{
         govukErrorSummary({
           titleText: 'There is a problem with the information you entered',
@@ -19,9 +19,9 @@
         }) if validationResult and validationResult.errors.length > 0
       }}
 
-      <form method="post">
-        <h1 class="govuk-heading-xl">Tell us why you’re appealing this penalty</h1>
-        <p class="govuk-body-l">Anything you tell us to support your appeal will be kept confidential.</p>
+      <form method='post'>
+        <h1 class='govuk-heading-xl'>Tell us why you’re appealing this penalty</h1>
+        <p class='govuk-body-l'>Anything you tell us to support your appeal will be kept confidential.</p>
 
         {{
           govukInput({

--- a/src/views/penalty-details.njk
+++ b/src/views/penalty-details.njk
@@ -1,8 +1,8 @@
-{% extends "layout.njk" %}
+{% extends 'layout.njk' %}
 
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/input/macro.njk"      import govukInput %}
-{% from "govuk/components/button/macro.njk"     import govukButton %}
+{% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
+{% from 'govuk/components/input/macro.njk'      import govukInput %}
+{% from 'govuk/components/button/macro.njk'     import govukButton %}
 
 
 {% block pageTitle %}
@@ -10,55 +10,55 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
         {{ 
           govukErrorSummary ({
-            titleText: "There is a problem with the details you gave us",
+            titleText: 'There is a problem with the details you gave us',
             errorList: validationResult.errors
           }) if validationResult and validationResult.errors.length > 0 
         }}
-      <h1 class="govuk-heading-xl">
+      <h1 class='govuk-heading-xl'>
         What are the penalty details?
       </h1>
-      <form method="post" action="">
+      <form method='post' action=''>
         {{ 
           govukInput({
             label: {
-              text: "Company number"
+              text: 'Company number'
             },
             hint: {
-              text: "This is the 8-character reference issued by Companies House when the company was set up."
+              text: 'This is the 8-character reference issued by Companies House when the company was set up.'
             },
-            errorMessage: validationResult.getErrorForField("companyNumber") if validationResult,
-            classes: "govuk-input--company-number",
-            id: "company-number",
-            name: "companyNumber",
+            errorMessage: validationResult.getErrorForField('companyNumber') if validationResult,
+            classes: 'govuk-input--company-number',
+            id: 'company-number',
+            name: 'companyNumber',
             value: companyNumber,
-            autocomplete: "off"
+            autocomplete: 'off'
           }) 
         }}
         {{ 
           govukInput({
             label: {
-              text: "Reference number"
+              text: 'Reference number'
             },
             hint: {
-              text: "This is the 9-character reference shown on the penalty notice."
+              text: 'This is the 9-character reference shown on the penalty notice.'
             },
-            errorMessage: validationResult.getErrorForField("penaltyReference") if validationResult,
-            classes: "govuk-input--penalty-reference",
-            id: "penalty-reference",
-            name: "penaltyReference",
+            errorMessage: validationResult.getErrorForField('penaltyReference') if validationResult,
+            classes: 'govuk-input--penalty-reference',
+            id: 'penalty-reference',
+            name: 'penaltyReference',
             value: penaltyReference,
-            autocomplete: "off"
+            autocomplete: 'off'
           }) 
         }}
         {{ 
           govukButton({
-            text: "Continue",
+            text: 'Continue',
             attributes: {
-              id: "submit"
+              id: 'submit'
             }
           }) 
         }}

--- a/src/views/penalty-details.njk
+++ b/src/views/penalty-details.njk
@@ -1,8 +1,8 @@
 {% extends 'layout.njk' %}
 
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
-{% from 'govuk/components/input/macro.njk'      import govukInput %}
-{% from 'govuk/components/button/macro.njk'     import govukButton %}
+{% from 'govuk/components/input/macro.njk'         import govukInput %}
+{% from 'govuk/components/button/macro.njk'        import govukButton %}
 
 
 {% block pageTitle %}
@@ -10,18 +10,18 @@
 {% endblock %}
 
 {% block content %}
-  <div class='govuk-grid-row'>
-    <div class='govuk-grid-column-two-thirds'>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
         {{ 
           govukErrorSummary ({
             titleText: 'There is a problem with the details you gave us',
             errorList: validationResult.errors
           }) if validationResult and validationResult.errors.length > 0 
         }}
-      <h1 class='govuk-heading-xl'>
+      <h1 class="govuk-heading-xl">
         What are the penalty details?
       </h1>
-      <form method='post' action=''>
+      <form method="post" action="">
         {{ 
           govukInput({
             label: {


### PR DESCRIPTION
### JIRA link

N/A

### Change description

Substitute double for single quotation and remove feedback banner from disclaimer page (different ticket handles that)

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
