### PR TITLE
refactor: use path mappings in imports

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "require": [
-    "ts-node/register"
+    "ts-node/register",
+    "tsconfig-paths/register"
   ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,8 @@ const sass = require('gulp-sass');
 const del = require('del');
 sass.compiler = require('node-sass');
 nodemon = require('gulp-nodemon');
-const tsProject = ts.createProject('tsconfig.json');
+const tsConfigFileName = 'tsconfig.json';
+const tsProject = ts.createProject(tsConfigFileName);
 const paths = {
     build: ['dist'],
     pages: ['src/views'],
@@ -30,7 +31,7 @@ gulp.task('start:watch', async () => nodemon({
     script: paths.build + '/app.js',
     watch: paths.src,
     ext: 'ts, scss, css, njk',
-    tasks: ['compile-project', 'copy-assets', 'copy-views', 'build-sass'],
+    tasks: ['build'],
     env: { 'DEBUG': 'Application,Request,Response' }
 }));
 
@@ -52,7 +53,11 @@ gulp.task('compile-project', function () {
         .js.pipe(gulp.dest(paths.build));
 });
 
-gulp.task('build', gulp.series('compile-project', gulp.parallel('copy-assets', 'copy-views', 'copy-govukfrontend', 'build-sass')));
+gulp.task('copy-descriptors', function () {
+    return gulp.src(tsConfigFileName).pipe(gulp.dest(paths.build));
+});
+
+gulp.task('build', gulp.series('compile-project', gulp.parallel('copy-assets', 'copy-views', 'copy-govukfrontend', 'build-sass', 'copy-descriptors')));
 
 gulp.task('build:clean', gulp.series('clean:build', 'build'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,12 @@
         "@types/node": "*"
       }
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -5241,6 +5247,15 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonfile": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -8627,6 +8642,26 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,8 +229,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -5414,7 +5413,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -8914,7 +8912,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
       "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-      "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -8925,8 +8922,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "kafka-node": "^5.0.0",
     "nunjucks": "^3.2.0",
     "reflect-metadata": "^0.1.13",
+    "tsconfig-paths": "^3.9.0",
     "tslib": "^1.11.1"
   },
   "devDependencies": {
@@ -61,7 +62,6 @@
     "sass-lint": "^1.13.1",
     "supertest": "^4.0.2",
     "ts-node": "^8.6.2",
-    "tsconfig-paths": "^3.9.0",
     "tslint": "^6.0.0",
     "typescript": "^3.8.3",
     "typescript-tslint-plugin": "^0.5.5"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.0.37",
-    "@types/ioredis": "^4.14.8",
     "@types/hapi__joi": "^16.0.12",
+    "@types/ioredis": "^4.14.8",
     "@types/mocha": "^7.0.1",
     "@types/nunjucks": "^3.1.3",
     "@types/supertest": "^2.0.8",
@@ -60,6 +60,7 @@
     "sass-lint": "^1.13.1",
     "supertest": "^4.0.2",
     "ts-node": "^8.6.2",
+    "tsconfig-paths": "^3.9.0",
     "tslint": "^6.0.0",
     "typescript": "^3.8.3",
     "typescript-tslint-plugin": "^0.5.5"

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,5 +1,7 @@
-import { Server } from './Server';
-import { loadEnvironmentVariablesFromFiles } from './utils/ConfigLoader';
+import './Bootstrap'
+
+import { Server } from 'app/Server';
+import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
 
 loadEnvironmentVariablesFromFiles();
 

--- a/src/Bootstrap.ts
+++ b/src/Bootstrap.ts
@@ -1,0 +1,6 @@
+import * as tsConfigPaths from 'tsconfig-paths'
+
+tsConfigPaths.register({
+    baseUrl: __dirname,
+    paths: require(`${__dirname}/tsconfig.json`).compilerOptions.paths
+});

--- a/src/ContainerFactory.ts
+++ b/src/ContainerFactory.ts
@@ -1,13 +1,14 @@
 import { Container } from 'inversify';
 import { buildProviderModule } from 'inversify-binding-decorators';
-import { CookieConfig, SessionMiddleware, SessionStore } from 'ch-node-session-handler';
-import { getEnvOrDefault } from './utils/EnvironmentUtils';
-import { AuthMiddleware } from './middleware/AuthMiddleware';
 import * as IORedis from 'ioredis'
 import * as kafka from 'kafka-node'
-import { EmailService } from './modules/email-publisher/EmailService'
-import { Payload, Producer } from './modules/email-publisher/producer/Producer'
+import { CookieConfig, SessionMiddleware, SessionStore } from 'ch-node-session-handler';
 import * as util from 'util'
+
+import { getEnvOrDefault } from 'app/utils/EnvironmentUtils';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { EmailService } from 'app/modules/email-publisher/EmailService'
+import { Payload, Producer } from 'app/modules/email-publisher/producer/Producer'
 
 function initiateKafkaClient (): kafka.KafkaClient {
     const connectionTimeoutInMillis: number = parseInt(

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import { InversifyExpressServer } from 'inversify-express-utils';
-import './controllers/index';
-import { createContainer } from './ContainerFactory';
-import { getExpressAppConfig } from './utils/ConfigLoader';
+import 'controllers/index';
+import { createContainer } from 'ContainerFactory';
+import { getExpressAppConfig } from 'utils/ConfigLoader';
 
 export class Server {
 

--- a/src/controllers/CheckYourAppealController.ts
+++ b/src/controllers/CheckYourAppealController.ts
@@ -1,19 +1,19 @@
 import { inject } from 'inversify'
 import { controller, httpGet, httpPost } from 'inversify-express-utils';
-import { CHECK_YOUR_APPEAL_PAGE_URI, CONFIRMATION_PAGE_URI } from '../utils/Paths';
+import { CHECK_YOUR_APPEAL_PAGE_URI, CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
 import { SessionKey } from 'ch-node-session-handler/lib/session/keys/SessionKey';
 import { SignInInfoKeys } from 'ch-node-session-handler/lib/session/keys/SignInInfoKeys';
 import { ISignInInfo, IUserProfile } from 'ch-node-session-handler/lib/session/model/SessionInterfaces';
 import { Request } from 'express';
-import { AuthMiddleware } from '../middleware/AuthMiddleware';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { Maybe, SessionMiddleware } from 'ch-node-session-handler';
-import { AppealKeys } from '../models/keys/AppealKeys';
-import { BaseAsyncHttpController } from './BaseAsyncHttpController';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
+import { BaseAsyncHttpController } from 'app/controllers/BaseAsyncHttpController';
 import { HttpResponseMessage } from 'inversify-express-utils/dts/httpResponseMessage';
 
-import { EmailService } from '../modules/email-publisher/EmailService'
-import { Appeal } from '../models/Appeal'
-import { PenaltyIdentifierKeys } from '../models/keys/PenaltyIdentifierKeys'
+import { EmailService } from 'app/modules/email-publisher/EmailService'
+import { Appeal } from 'app/models/Appeal'
+import { PenaltyIdentifierKeys } from 'app/models/keys/PenaltyIdentifierKeys'
 
 @controller(CHECK_YOUR_APPEAL_PAGE_URI, SessionMiddleware, AuthMiddleware)
 export class CheckYourAppealController extends BaseAsyncHttpController {

--- a/src/controllers/ConfirmationController.ts
+++ b/src/controllers/ConfirmationController.ts
@@ -1,11 +1,11 @@
 import { controller, httpGet } from 'inversify-express-utils';
-import { CONFIRMATION_PAGE_URI } from '../utils/Paths';
+import { CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
 import { Request } from 'express';
 import { SessionMiddleware } from 'ch-node-session-handler';
-import { AuthMiddleware } from '../middleware/AuthMiddleware';
-import { AppealKeys } from '../models/keys/AppealKeys';
-import { PenaltyIdentifierKeys } from '../models/keys/PenaltyIdentifierKeys';
-import { BaseAsyncHttpController } from './BaseAsyncHttpController';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
+import { PenaltyIdentifierKeys } from 'app/models/keys/PenaltyIdentifierKeys';
+import { BaseAsyncHttpController } from 'app/controllers/BaseAsyncHttpController';
 import { SessionKey } from 'ch-node-session-handler/lib/session/keys/SessionKey'
 import { ISignInInfo } from 'ch-node-session-handler/lib/session/model/SessionInterfaces'
 import { SignInInfoKeys } from 'ch-node-session-handler/lib/session/keys/SignInInfoKeys'

--- a/src/controllers/EntryController.ts
+++ b/src/controllers/EntryController.ts
@@ -1,5 +1,5 @@
 import { controller, httpGet, BaseHttpController } from 'inversify-express-utils';
-import { PENALTY_DETAILS_PAGE_URI, ENTRY_PAGE_URI } from '../utils/Paths';
+import { PENALTY_DETAILS_PAGE_URI, ENTRY_PAGE_URI } from 'app/utils/Paths';
 
 @controller(ENTRY_PAGE_URI)
 export class EntryController extends BaseHttpController{

--- a/src/controllers/HealthCheckController.ts
+++ b/src/controllers/HealthCheckController.ts
@@ -1,7 +1,7 @@
 import { inject } from 'inversify';
 import { BaseHttpController, httpGet, controller } from 'inversify-express-utils';
 import { OK, INTERNAL_SERVER_ERROR } from 'http-status-codes';
-import { HEALTH_CHECK_URI } from '../utils/Paths';
+import { HEALTH_CHECK_URI } from 'app/utils/Paths';
 import { SessionStore } from 'ch-node-session-handler';
 
 @controller(HEALTH_CHECK_URI)

--- a/src/controllers/LandingController.ts
+++ b/src/controllers/LandingController.ts
@@ -1,5 +1,5 @@
 import { controller, httpGet, httpPost, BaseHttpController } from 'inversify-express-utils';
-import { ROOT_URI, ENTRY_PAGE_URI } from '../utils/Paths';
+import { ROOT_URI, ENTRY_PAGE_URI } from 'app/utils/Paths';
 
 @controller(ROOT_URI)
 export class LandingController extends BaseHttpController {

--- a/src/controllers/OtherReasonController.ts
+++ b/src/controllers/OtherReasonController.ts
@@ -1,19 +1,19 @@
 import { inject } from 'inversify';
 import { BaseHttpController, controller, httpGet, httpPost } from 'inversify-express-utils';
-import { OTHER_REASON_PAGE_URI, CHECK_YOUR_APPEAL_PAGE_URI } from '../utils/Paths';
-import { SchemaValidator } from '../utils/validation/SchemaValidator';
-import { ValidationResult } from '../utils/validation/ValidationResult';
-import { OtherReason } from '../models/OtherReason';
-import { schema } from '../models/OtherReason.schema';
+import { OTHER_REASON_PAGE_URI, CHECK_YOUR_APPEAL_PAGE_URI } from 'app/utils/Paths';
+import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { OtherReason } from 'app/models/OtherReason';
+import { schema } from 'app/models/OtherReason.schema';
 import { OK, UNPROCESSABLE_ENTITY } from 'http-status-codes';
 import { Request } from 'express';
 import { Cookie } from 'ch-node-session-handler/lib/session/model/Cookie';
 import { SessionMiddleware, SessionStore, Maybe } from 'ch-node-session-handler';
-import { AuthMiddleware } from '../middleware/AuthMiddleware';
-import { AppealKeys } from '../models/keys/AppealKeys';
-import { ReasonsKeys } from '../models/keys/ReasonsKeys';
-import { Appeal } from '../models/Appeal';
-import { getEnvOrDefault } from '../utils/EnvironmentUtils';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
+import { ReasonsKeys } from 'app/models/keys/ReasonsKeys';
+import { Appeal } from 'app/models/Appeal';
+import { getEnvOrDefault } from 'app/utils/EnvironmentUtils';
 
 @controller(OTHER_REASON_PAGE_URI, SessionMiddleware, AuthMiddleware)
 export class OtherReasonController extends BaseHttpController {

--- a/src/controllers/OtherReasonDisclaimerController.ts
+++ b/src/controllers/OtherReasonDisclaimerController.ts
@@ -1,8 +1,8 @@
 import { controller, httpGet, httpPost } from 'inversify-express-utils';
-import { OTHER_REASON_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../utils/Paths';
+import { OTHER_REASON_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from 'app/utils/Paths';
 import { SessionMiddleware } from 'ch-node-session-handler';
-import { AuthMiddleware } from '../middleware/AuthMiddleware';
-import { BaseAsyncHttpController } from './BaseAsyncHttpController';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { BaseAsyncHttpController } from 'app/controllers/BaseAsyncHttpController';
 
 @controller(OTHER_REASON_DISCLAIMER_PAGE_URI, SessionMiddleware, AuthMiddleware)
 export class OtherReasonDisclaimerController extends BaseAsyncHttpController {

--- a/src/controllers/PenaltyDetailsController.ts
+++ b/src/controllers/PenaltyDetailsController.ts
@@ -1,21 +1,21 @@
 import { controller, httpGet, httpPost } from 'inversify-express-utils';
 import { inject } from 'inversify';
 import { UNPROCESSABLE_ENTITY } from 'http-status-codes';
-import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../utils/Paths';
-import { BaseAsyncHttpController } from './BaseAsyncHttpController';
-import { ValidationResult } from '../utils/validation/ValidationResult';
-import { SchemaValidator } from '../utils/validation/SchemaValidator';
+import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from 'app/utils/Paths';
+import { BaseAsyncHttpController } from 'app/controllers/BaseAsyncHttpController';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
 import { Request } from 'express';
 import { Cookie } from 'ch-node-session-handler/lib/session/model/Cookie';
-import { AuthMiddleware } from '../middleware/AuthMiddleware';
-import { PenaltyIdentifier } from '../models/PenaltyIdentifier';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
 import { SessionMiddleware, SessionStore, Maybe } from 'ch-node-session-handler';
-import { schema } from '../models/PenaltyIdentifier.schema';
-import { AppealKeys } from '../models/keys/AppealKeys';
-import { Appeal } from '../models/Appeal';
-import { getEnvOrDefault } from '../utils/EnvironmentUtils';
-import { PenaltyIdentifierKeys } from '../models/keys/PenaltyIdentifierKeys';
-import { sanitize } from '../utils/CompanyNumberSanitizer';
+import { schema } from 'app/models/PenaltyIdentifier.schema';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
+import { Appeal } from 'app/models/Appeal';
+import { getEnvOrDefault } from 'app/utils/EnvironmentUtils';
+import { PenaltyIdentifierKeys } from 'app/models/keys/PenaltyIdentifierKeys';
+import { sanitize } from 'app/utils/CompanyNumberSanitizer';
 
 @controller(PENALTY_DETAILS_PAGE_URI, SessionMiddleware, AuthMiddleware)
 export class PenaltyDetailsController extends BaseAsyncHttpController {

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,8 +1,8 @@
-import './HealthCheckController';
-import './EntryController'
-import './PenaltyDetailsController';
-import './OtherReasonController';
-import './LandingController';
-import './OtherReasonDisclaimerController';
-import './CheckYourAppealController';
-import './ConfirmationController';
+import 'app/controllers/HealthCheckController';
+import 'app/controllers/EntryController'
+import 'app/controllers/PenaltyDetailsController';
+import 'app/controllers/OtherReasonController';
+import 'app/controllers/LandingController';
+import 'app/controllers/OtherReasonDisclaimerController';
+import 'app/controllers/CheckYourAppealController';
+import 'app/controllers/ConfirmationController';

--- a/src/middleware/AuthMiddleware.ts
+++ b/src/middleware/AuthMiddleware.ts
@@ -5,7 +5,7 @@ import { SessionKey } from 'ch-node-session-handler/lib/session/keys/SessionKey'
 import { SignInInfoKeys } from 'ch-node-session-handler/lib/session/keys/SignInInfoKeys';
 import { injectable } from 'inversify';
 import { Session } from 'ch-node-session-handler/lib/session/model/Session';
-import { PENALTY_DETAILS_PAGE_URI } from '../utils/Paths';
+import { PENALTY_DETAILS_PAGE_URI } from 'app/utils/Paths';
 
 @injectable()
 export class AuthMiddleware extends BaseMiddleware {

--- a/src/models/Appeal.ts
+++ b/src/models/Appeal.ts
@@ -1,6 +1,6 @@
-import { PenaltyIdentifier } from './PenaltyIdentifier';
-import { Reasons } from './Reasons';
-import { AppealKeys } from './keys/AppealKeys';
+import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
+import { Reasons } from 'app/models/Reasons';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
 
 export interface Appeal {
     [AppealKeys.PENALTY_IDENTIFIER]: PenaltyIdentifier;

--- a/src/models/OtherReason.ts
+++ b/src/models/OtherReason.ts
@@ -1,4 +1,4 @@
-import { OtherReasonKeys } from './keys/OtherReasonKeys';
+import { OtherReasonKeys } from 'app/models/keys/OtherReasonKeys';
 
 export interface OtherReason {
     [OtherReasonKeys.TITLE]: string

--- a/src/models/PenaltyIdentifier.ts
+++ b/src/models/PenaltyIdentifier.ts
@@ -1,4 +1,4 @@
-import { PenaltyIdentifierKeys } from './keys/PenaltyIdentifierKeys';
+import { PenaltyIdentifierKeys } from 'app/models/keys/PenaltyIdentifierKeys';
 
 export interface PenaltyIdentifier {
     [PenaltyIdentifierKeys.COMPANY_NUMBER]: string;

--- a/src/models/Reasons.ts
+++ b/src/models/Reasons.ts
@@ -1,5 +1,5 @@
-import { OtherReason } from './OtherReason';
-import { ReasonsKeys } from './keys/ReasonsKeys';
+import { OtherReason } from 'app/models/OtherReason';
+import { ReasonsKeys } from 'app/models/keys/ReasonsKeys';
 
 export interface Reasons {
   [ReasonsKeys.OTHER]: OtherReason;

--- a/src/modules/email-publisher/EmailService.ts
+++ b/src/modules/email-publisher/EmailService.ts
@@ -1,8 +1,8 @@
 import * as crypto from 'crypto'
 
-import { Email } from './Email'
-import { Producer } from './producer/Producer'
-import { Message, type } from './message/Message'
+import { Email } from 'app/modules/email-publisher/Email'
+import { Producer } from 'app/modules/email-publisher/producer/Producer'
+import { Message, type } from 'app/modules/email-publisher/message/Message'
 
 export class EmailService {
 

--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -4,8 +4,8 @@ import * as path from 'path';
 import * as nunjucks from 'nunjucks';
 import bodyParser = require('body-parser');
 import cookieParser = require('cookie-parser');
-import { handler } from '../middleware/ErrorHandler';
-import { ROOT_URI } from './Paths';
+import { handler } from 'app/middleware/ErrorHandler';
+import { ROOT_URI } from 'app/utils/Paths';
 
 const DEFAULT_ENV_FILE = `${__dirname}/../../.env`;
 

--- a/src/utils/validation/SchemaValidator.ts
+++ b/src/utils/validation/SchemaValidator.ts
@@ -1,6 +1,6 @@
 import { AnySchema, ValidationOptions } from '@hapi/joi';
-import { ValidationResult } from './ValidationResult';
-import { ValidationError } from './ValidationError';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 const validationOptions: ValidationOptions = {
     abortEarly: false,

--- a/src/utils/validation/ValidationResult.ts
+++ b/src/utils/validation/ValidationResult.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from './ValidationError';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 export class ValidationResult {
     constructor (public readonly errors: ValidationError[] = []) {}

--- a/test/ApplicationFactory.ts
+++ b/test/ApplicationFactory.ts
@@ -1,13 +1,13 @@
 import { Container } from 'inversify';
 import { Application, NextFunction, RequestHandler, Request, Response } from 'express';
 import { InversifyExpressServer } from 'inversify-express-utils';
-import { getExpressAppConfig, loadEnvironmentVariablesFromFiles } from '../src/utils/ConfigLoader';
-import { AuthMiddleware } from '../src/middleware/AuthMiddleware';
-import { getEnvOrDefault } from '../src/utils/EnvironmentUtils';
+import { getExpressAppConfig, loadEnvironmentVariablesFromFiles } from 'utils/ConfigLoader';
+import { AuthMiddleware } from 'middleware/AuthMiddleware';
+import { getEnvOrDefault } from 'utils/EnvironmentUtils';
 import { Maybe, SessionStore, EitherUtils, SessionMiddleware, Session } from 'ch-node-session-handler';
 import { Cookie } from 'ch-node-session-handler/lib/session/model/Cookie';
 import Substitute from '@fluffy-spoon/substitute';
-import { EmailService } from '../src/modules/email-publisher/EmailService'
+import { EmailService } from 'modules/email-publisher/EmailService'
 
 export const createAppConfigurable = (configureContainerBindings: (container: Container) => void = () => { }): Application => {
 

--- a/test/controllers/CheckYourAppealController.test.ts
+++ b/test/controllers/CheckYourAppealController.test.ts
@@ -1,14 +1,14 @@
 import 'reflect-metadata';
-import '../../src/controllers/CheckYourAppealController';
+import 'app/controllers/CheckYourAppealController';
 import * as request from 'supertest';
-import { CHECK_YOUR_APPEAL_PAGE_URI, CONFIRMATION_PAGE_URI } from '../../src/utils/Paths';
+import { CHECK_YOUR_APPEAL_PAGE_URI, CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
 import { INTERNAL_SERVER_ERROR, MOVED_TEMPORARILY, OK } from 'http-status-codes';
 import { expect } from 'chai';
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
-import { Appeal } from '../../src/models/Appeal';
-import { createSubstituteOf } from '../SubstituteFactory'
-import { EmailService } from '../../src/modules/email-publisher/EmailService'
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
+import { Appeal } from 'app/models/Appeal';
+import { createSubstituteOf } from 'test/SubstituteFactory'
+import { EmailService } from 'app/modules/email-publisher/EmailService'
 import { Arg } from '@fluffy-spoon/substitute'
 
 const config = getDefaultConfig();

--- a/test/controllers/ConfirmationController.test.ts
+++ b/test/controllers/ConfirmationController.test.ts
@@ -2,12 +2,12 @@ import 'reflect-metadata';
 import * as request from 'supertest';
 import { expect } from 'chai';
 
-import '../../src/controllers/ConfirmationController';
-import { CONFIRMATION_PAGE_URI } from '../../src/utils/Paths';
+import 'app/controllers/ConfirmationController';
+import { CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
 import { OK } from 'http-status-codes';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
-import { getDefaultConfig, createApp } from '../ApplicationFactory';
-import { Appeal } from '../../src/models/Appeal';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
+import { getDefaultConfig, createApp } from 'test/ApplicationFactory';
+import { Appeal } from 'app/models/Appeal';
 
 const config = getDefaultConfig();
 

--- a/test/controllers/EntryController.test.ts
+++ b/test/controllers/EntryController.test.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata'
-import '../../src/controllers/EntryController'
+import 'app/controllers/EntryController'
 import * as request from 'supertest'
 import { MOVED_TEMPORARILY  } from 'http-status-codes';
-import { ENTRY_PAGE_URI, PENALTY_DETAILS_PAGE_URI } from '../../src/utils/Paths';
+import { ENTRY_PAGE_URI, PENALTY_DETAILS_PAGE_URI } from 'app/utils/Paths';
 import { expect } from 'chai';
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
 
 const config = getDefaultConfig()
 describe('EntryController', () => {

--- a/test/controllers/HealthCheckController.test.ts
+++ b/test/controllers/HealthCheckController.test.ts
@@ -1,14 +1,14 @@
 import 'reflect-metadata'
 import { Application } from 'express'
 import * as request from 'supertest'
-import { createAppConfigurable } from '../ApplicationFactory';
-import { createSubstituteOf } from '../SubstituteFactory';
+import { createAppConfigurable } from 'test/ApplicationFactory';
+import { createSubstituteOf } from 'test/SubstituteFactory';
 
-import '../../src/controllers/HealthCheckController'
+import 'app/controllers/HealthCheckController'
 import { Redis } from 'ioredis';
 import { SessionStore } from 'ch-node-session-handler';
-import { HEALTH_CHECK_URI } from '../../src/utils/Paths';
-import { EmailService } from '../../src/modules/email-publisher/EmailService'
+import { HEALTH_CHECK_URI } from 'app/utils/Paths';
+import { EmailService } from 'app/modules/email-publisher/EmailService'
 
 describe('HealthCheckController', () => {
     it('should return 200 with status when redis database is up', async () => {

--- a/test/controllers/OtherReasonController.test.ts
+++ b/test/controllers/OtherReasonController.test.ts
@@ -2,12 +2,12 @@ import 'reflect-metadata';
 
 import * as request from 'supertest';
 import { expect } from 'chai';
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
-import '../../src/controllers/OtherReasonController';
-import { OTHER_REASON_PAGE_URI, CHECK_YOUR_APPEAL_PAGE_URI } from '../../src/utils/Paths';
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
+import 'app/controllers/OtherReasonController';
+import { OTHER_REASON_PAGE_URI, CHECK_YOUR_APPEAL_PAGE_URI } from 'app/utils/Paths';
 import { OK, UNPROCESSABLE_ENTITY, MOVED_TEMPORARILY } from 'http-status-codes';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
-import { Appeal } from '../../src/models/Appeal';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
+import { Appeal } from 'app/models/Appeal';
 const pageHeading = 'Tell us why you’re appealing this penalty';
 const errorSummaryHeading = 'There is a problem with the information you entered';
 const invalidTitleErrorMessage = 'You must give your reason a title';

--- a/test/controllers/OtherReasonDisclaimerController.test.ts
+++ b/test/controllers/OtherReasonDisclaimerController.test.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata'
 
-import '../../src/controllers/OtherReasonDisclaimerController'
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
-import { OTHER_REASON_DISCLAIMER_PAGE_URI, OTHER_REASON_PAGE_URI } from '../../src/utils/Paths';
+import 'app/controllers/OtherReasonDisclaimerController'
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
+import { OTHER_REASON_DISCLAIMER_PAGE_URI, OTHER_REASON_PAGE_URI } from 'app/utils/Paths';
 import * as request from 'supertest'
 import { expect } from 'chai';
 import { OK, MOVED_TEMPORARILY } from 'http-status-codes';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
 
 const config = getDefaultConfig();
 

--- a/test/controllers/PenaltyDetailsController.test.ts
+++ b/test/controllers/PenaltyDetailsController.test.ts
@@ -1,15 +1,15 @@
 import 'reflect-metadata';
 
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
 import * as request from 'supertest';
-import '../../src/controllers/PenaltyDetailsController';
+import 'app/controllers/PenaltyDetailsController';
 import { MOVED_TEMPORARILY, OK, UNPROCESSABLE_ENTITY } from 'http-status-codes';
 import { expect } from 'chai';
-import { PenaltyIdentifier } from '../../src/models/PenaltyIdentifier';
-import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from '../../src/utils/Paths';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
-import { AppealKeys } from '../../src/models/keys/AppealKeys';
-import { Appeal } from '../../src/models/Appeal';
+import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
+import { PENALTY_DETAILS_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI } from 'app/utils/Paths';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
+import { AppealKeys } from 'app/models/keys/AppealKeys';
+import { Appeal } from 'app/models/Appeal';
 
 const pageHeading = 'What are the penalty details?';
 const errorSummaryHeading = 'There is a problem with the information you entered';

--- a/test/middleware/AuthMiddleware.test.ts
+++ b/test/middleware/AuthMiddleware.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import '../../src/controllers/index';
+import 'app/controllers/index';
 import { expect } from 'chai';
 import * as request from 'supertest';
 import {
@@ -8,15 +8,15 @@ import {
     PENALTY_DETAILS_PAGE_URI,
     CONFIRMATION_PAGE_URI,
     CHECK_YOUR_APPEAL_PAGE_URI
-} from '../../src/utils/Paths';
-import { createApp, getDefaultConfig } from '../ApplicationFactory';
-import { createFakeSession } from '../utils/session/FakeSessionFactory';
+} from 'app/utils/Paths';
+import { createApp, getDefaultConfig } from 'test/ApplicationFactory';
+import { createFakeSession } from 'test/utils/session/FakeSessionFactory';
 import { SessionKey } from 'ch-node-session-handler/lib/session/keys/SessionKey';
 import { generateSessionId, generateSignature } from 'ch-node-session-handler/lib/utils/CookieUtils';
-import { PenaltyIdentifier } from '../../src/models/PenaltyIdentifier';
+import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
 import Substitute, { Arg } from '@fluffy-spoon/substitute';
 import { Request, Response, NextFunction } from 'express';
-import { AuthMiddleware } from '../../src/middleware/AuthMiddleware';
+import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { Maybe } from 'ch-node-session-handler';
 
 const config = getDefaultConfig();

--- a/test/models/OtherReasonSchema.test.ts
+++ b/test/models/OtherReasonSchema.test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
-import { schema } from '../../src/models/OtherReason.schema';
-import { SchemaValidator } from '../../src/utils/validation/SchemaValidator';
-import { ValidationResult } from '../../src/utils/validation/ValidationResult';
-import { ValidationError } from '../../src/utils/validation/ValidationError';
+import { schema } from 'app/models/OtherReason.schema';
+import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 const validator = new SchemaValidator(schema);
 

--- a/test/models/PenaltyEntrySchema.test.ts
+++ b/test/models/PenaltyEntrySchema.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { SchemaValidator } from '../../src/utils/validation/SchemaValidator';
-import { PenaltyIdentifier } from '../../src/models/PenaltyIdentifier';
-import { schema } from '../../src/models/PenaltyIdentifier.schema'
+import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
+import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
+import { schema } from 'app/models/PenaltyIdentifier.schema'
 
 
 describe('Penalty Details Schema Validation', () => {

--- a/test/modules/email-publisher/EmailService.test.ts
+++ b/test/modules/email-publisher/EmailService.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
-import { createSubstituteOf } from '../../SubstituteFactory'
+import { createSubstituteOf } from 'test/SubstituteFactory'
 
 import { Arg } from '@fluffy-spoon/substitute'
-import { EmailService } from '../../../src/modules/email-publisher/EmailService'
-import { Payload, Producer } from '../../../src/modules/email-publisher/producer/Producer'
-import { Message, type } from '../../../src/modules/email-publisher/message/Message'
+import { EmailService } from 'app/modules/email-publisher/EmailService'
+import { Payload, Producer } from 'app/modules/email-publisher/producer/Producer'
+import { Message, type } from 'app/modules/email-publisher/message/Message'
 
 const applicationIdentifier = 'frontend';
 

--- a/test/utils/CompanyNumberSanitizer.test.ts
+++ b/test/utils/CompanyNumberSanitizer.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { sanitize } from '../../src/utils/CompanyNumberSanitizer'
+import { sanitize } from 'app/utils/CompanyNumberSanitizer'
 
 describe('CompanyNumberSanitizer', () => {
     it('should throw error when company number undefined or empty', () =>{

--- a/test/utils/validation/SchemaValidator.test.ts
+++ b/test/utils/validation/SchemaValidator.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import * as Joi from '@hapi/joi';
 
-import { SchemaValidator } from '../../../src/utils/validation/SchemaValidator';
-import { ValidationError } from '../../../src/utils/validation/ValidationError';
+import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 describe('SchemaValidator', () => {
     describe('instance creation', () => {

--- a/test/utils/validation/ValidationError.test.ts
+++ b/test/utils/validation/ValidationError.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { ValidationError } from '../../../src/utils/validation/ValidationError';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 describe('ValidationError', () => {
     describe('instance creation', () => {

--- a/test/utils/validation/ValidationResult.test.ts
+++ b/test/utils/validation/ValidationResult.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { ValidationResult } from '../../../src/utils/validation/ValidationResult';
-import { ValidationError } from '../../../src/utils/validation/ValidationError';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { ValidationError } from 'app/utils/validation/ValidationError';
 
 const error = new ValidationError('field', 'Unexpected error');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
       "module": "commonjs",
       "strict": true,
       "pretty": true,
-      "baseUrl": "./",
+      "baseUrl": "./src",
       "removeComments": true,
       "experimentalDecorators": true,
       "target": "es6",
@@ -14,7 +14,11 @@
         {
           "name": "typescript-tslint-plugin"
         }
-      ]
+      ],
+      "paths": {
+        "app/*": ["./*"],
+        "test/*": ["../test/*"]
+      }
     },
     "include": [
       "./src/**/*.ts"


### PR DESCRIPTION
### JIRA link

None

### Change description

This PR introduces `tsconfig-paths` to make use of arbitrary paths.

Benefits of the approach:
- shorter and consistent import approach (change from `../../src/utils/validation/SchemaValidator` to `app/utils/validation/SchemaValidator`
- more durable paths that survive copy-paste :)

With the solution in place there are only two possibilities:
- paths that start with `app/` that loads resources from `src` directory
- paths that start with `test/` that loads resources from `test` directory

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
