### PR TITLE
fix: make penalty reference uppercase before saving to session

### DIFF
--- a/src/controllers/PenaltyDetailsController.ts
+++ b/src/controllers/PenaltyDetailsController.ts
@@ -58,7 +58,7 @@ export class PenaltyDetailsController extends BaseAsyncHttpController {
         const changePenaltyIdentifier = (appeal: Appeal) => {
 
             const companyNumber = sanitize(body.companyNumber);
-            const penaltyReference = body.penaltyReference;
+            const penaltyReference = body.penaltyReference.toUpperCase();
 
             appeal.penaltyIdentifier.companyNumber = companyNumber;
             appeal.penaltyIdentifier.penaltyReference = penaltyReference;
@@ -71,7 +71,7 @@ export class PenaltyDetailsController extends BaseAsyncHttpController {
             .mapOrDefault(changePenaltyIdentifier, Maybe.of({
                 penaltyIdentifier: {
                     companyNumber: sanitize(body.companyNumber),
-                    penaltyReference: body.penaltyReference
+                    penaltyReference: body.penaltyReference.toUpperCase()
                 }
             } as Appeal))
             .mapOrDefault(_ => _, {} as Appeal);


### PR DESCRIPTION
### JIRA link
NO JIRA


### Change description
Converted penalty reference to uppercase on penalty details submission

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
