### PR TITLE
refactor: load test environment variables in one place

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "require": [
     "ts-node/register",
-    "tsconfig-paths/register"
+    "tsconfig-paths/register",
+    "LoadConfig"
   ]
 }

--- a/test/ApplicationFactory.ts
+++ b/test/ApplicationFactory.ts
@@ -10,7 +10,6 @@ import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationDat
 import { EmailService } from 'app/modules/email-publisher/EmailService'
 import { FileTransferService } from 'app/modules/file-transfer-service/FileTransferService';
 import { AppealStorageService } from 'app/service/AppealStorageService';
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
 import { getEnvOrThrow } from 'app/utils/EnvironmentUtils';
 
 import { createSession } from 'test/utils/session/SessionFactory';
@@ -18,7 +17,6 @@ import { createSession } from 'test/utils/session/SessionFactory';
 // tslint:disable-next-line:no-empty
 export const createAppConfigurable = (configureBindings: (container: Container) => void = () => {}): Application => {
 
-    loadEnvironmentVariablesFromFiles();
     const container = new Container();
     container.load(buildProviderModule());
     configureBindings(container);

--- a/test/controllers/BaseController.test.ts
+++ b/test/controllers/BaseController.test.ts
@@ -1,7 +1,4 @@
 import 'reflect-metadata'
-// tslint:disable-next-line: ordered-imports
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
-loadEnvironmentVariablesFromFiles();
 
 import { Arg } from '@fluffy-spoon/substitute';
 import { AnySchema } from '@hapi/joi';

--- a/test/controllers/EvidenceRemovalController.test.ts
+++ b/test/controllers/EvidenceRemovalController.test.ts
@@ -1,20 +1,17 @@
 import 'reflect-metadata'
-// tslint:disable-next-line: ordered-imports
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
 
-loadEnvironmentVariablesFromFiles();
+import { SubstituteOf } from '@fluffy-spoon/substitute';
 import { expect } from 'chai';
 import { INTERNAL_SERVER_ERROR, MOVED_TEMPORARILY, OK, UNPROCESSABLE_ENTITY } from 'http-status-codes';
 import request from 'supertest';
 
 import 'app/controllers/EvidenceRemovalController'
+import { Appeal } from 'app/models/Appeal';
 import { Attachment } from 'app/models/Attachment';
 import { YesNo } from 'app/models/fields/YesNo';
+import { FileTransferService } from 'app/modules/file-transfer-service/FileTransferService';
 import { EVIDENCE_REMOVAL_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI } from 'app/utils/Paths';
 
-import { SubstituteOf } from '@fluffy-spoon/substitute';
-import { Appeal } from 'app/models/Appeal';
-import { FileTransferService } from 'app/modules/file-transfer-service/FileTransferService';
 import { createApp } from 'test/ApplicationFactory';
 import { createSubstituteOf } from 'test/SubstituteFactory';
 

--- a/test/controllers/SafeNavigationBaseController.test.ts
+++ b/test/controllers/SafeNavigationBaseController.test.ts
@@ -1,7 +1,4 @@
 import 'reflect-metadata'
-// tslint:disable-next-line: ordered-imports
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
-loadEnvironmentVariablesFromFiles();
 
 import { Arg } from '@fluffy-spoon/substitute';
 import { EitherUtils, ISession, Maybe, Session, SessionStore } from 'ch-node-session-handler';

--- a/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
+++ b/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
@@ -12,13 +12,10 @@ import { InternalEmailFormActionProcessor } from 'app/controllers/processors/Int
 import { Appeal } from 'app/models/Appeal';
 import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { EmailService } from 'app/modules/email-publisher/EmailService';
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
 
 import { createSubstituteOf } from 'test/SubstituteFactory';
 
 describe('InternalEmailFormSubmissionProcessor', () => {
-    loadEnvironmentVariablesFromFiles();
-
     it('should throw error when session does not exist', async () => {
         const emailService = createSubstituteOf<EmailService>();
 

--- a/test/middleware/FileTransferFeatureMiddleware.test.ts
+++ b/test/middleware/FileTransferFeatureMiddleware.test.ts
@@ -1,11 +1,9 @@
 import 'reflect-metadata'
-// tslint:disable-next-line: ordered-imports
-import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
-loadEnvironmentVariablesFromFiles();
 
 import Substitute, { Arg } from '@fluffy-spoon/substitute';
 import { expect } from 'chai';
 import { NextFunction, Request, Response } from 'express';
+import { MOVED_TEMPORARILY, OK } from 'http-status-codes';
 import { after, before } from 'mocha';
 import request from 'supertest';
 
@@ -13,7 +11,6 @@ import 'app/controllers/EvidenceUploadController'
 import { FileTransferFeatureMiddleware } from 'app/middleware/FileTransferFeatureMiddleware';
 import { ENTRY_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI } from 'app/utils/Paths';
 
-import { MOVED_TEMPORARILY, OK } from 'http-status-codes';
 import { createApp } from 'test/ApplicationFactory';
 
 let initialFileTransferFlag: string | undefined;


### PR DESCRIPTION
### JIRA link

None

### Change description

In nutshell it loads env variables from `.env.local` in single place (when mocha framework loads itself) for any test so there is no longer need to manually load config in every test file. As a consequence it is much easier to run single test in IDE

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
