### PR TITLE
feat: add continue without evidence transition

### DIFF
--- a/src/controllers/EvidenceUploadController.ts
+++ b/src/controllers/EvidenceUploadController.ts
@@ -138,6 +138,34 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
 
                     response.redirect(request.route.path);
                 }
+            },
+            'continue-without-upload': {
+                async handle(request: Request, response: Response): Promise<void> {
+
+                    if (that.formActionProcessors != null) {
+                        for (const actionProcessorType of that.formActionProcessors) {
+                            const actionProcessor = that.httpContext.container.get(actionProcessorType);
+                            await actionProcessor.process(request, response);
+                        }
+                    }
+
+                    const session = request.session.extract();
+                    if (session != null) {
+                        const applicationData: ApplicationData = session.getExtraData()
+                            .map<ApplicationData>(data => data[APPLICATION_DATA_KEY])
+                            .orDefaultLazy(() => {
+                                const value = {} as ApplicationData;
+                                session.saveExtraData(APPLICATION_DATA_KEY, value);
+                                return value;
+                            });
+
+                        // tslint:disable-next-line: max-line-length
+                        applicationData.appeal = that.prepareSessionModelPriorSave(applicationData.appeal || {}, request.body);
+                        await that.persistSession();
+                    }
+
+                    return response.redirect(that.navigation.next(request));
+                }
             }
         };
     }

--- a/src/controllers/EvidenceUploadController.ts
+++ b/src/controllers/EvidenceUploadController.ts
@@ -159,8 +159,9 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
                                 return value;
                             });
 
-                        // tslint:disable-next-line: max-line-length
-                        applicationData.appeal = that.prepareSessionModelPriorSave(applicationData.appeal || {}, request.body);
+                        applicationData.appeal =
+                            that.prepareSessionModelPriorSave(applicationData.appeal || {}, request.body);
+
                         await that.persistSession();
                     }
 

--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -119,7 +119,7 @@
       </p>
 
 
-      <form method="post">
+      <form method="post" action="?action=continue-without-upload">
         <button role="link" type="submit" id="no-evidence-link" class="btn-link" >
           Continue without adding documents
         </button>

--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -20,6 +20,21 @@
 {% endblock %}
 
 {% block content %}
+
+  <style>
+    .btn-link {
+      border: none;
+      outline: none;
+      background: none;
+      cursor: pointer;
+      color: #0000EE;
+      padding: 0;
+      text-decoration: underline;
+      font-family: inherit;
+      font-size: inherit;
+    }
+  </style>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{
@@ -95,6 +110,14 @@
       <p>
         <a href="{{ navigation.forward.href }}" class="govuk-link">Continue without adding documents</a>
       </p>
+
+
+      <form method="post">
+        <button type="submit" class="btn-link" >
+          This is a link that sends a POST request
+        </button>
+      </form>
+
     </div>
   </div>
 {% endblock %}

--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -20,28 +20,6 @@
 {% endblock %}
 
 {% block content %}
-
-  <style>
-    .btn-link {
-      border: none;
-      outline: none;
-      background: none;
-      cursor: pointer;
-      color: #0000EE;
-      padding: 0;
-      text-decoration: underline;
-      font-family: "GDS Transport", Arial, sans-serif;
-      font-size: 19px;
-      -webkit-font-smoothing:antialiased;
-      -moz-osx-font-smoothing:grayscale;
-    }
-    .btn-link:focus{color:#0b0c0c;background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;text-decoration:none}
-    .btn-link:link{color:#1d70b8}
-    .btn-link:visited{color:#4c2c92}
-    .btn-link:hover{color:#003078}
-    .btn-link:active{color:#0b0c0c}
-  </style>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{
@@ -113,11 +91,6 @@
           })
         }}
       </form>
-
-      <p>
-        <a href="{{ navigation.forward.href }}" class="govuk-link">Continue without adding documents</a>
-      </p>
-
 
       <form method="post" action="?action=continue-without-upload">
         <button role="link" type="submit" id="no-evidence-link" class="btn-link" >

--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -30,9 +30,16 @@
       color: #0000EE;
       padding: 0;
       text-decoration: underline;
-      font-family: inherit;
-      font-size: inherit;
+      font-family: "GDS Transport", Arial, sans-serif;
+      font-size: 19px;
+      -webkit-font-smoothing:antialiased;
+      -moz-osx-font-smoothing:grayscale;
     }
+    .btn-link:focus{color:#0b0c0c;background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;text-decoration:none}
+    .btn-link:link{color:#1d70b8}
+    .btn-link:visited{color:#4c2c92}
+    .btn-link:hover{color:#003078}
+    .btn-link:active{color:#0b0c0c}
   </style>
 
   <div class="govuk-grid-row">
@@ -113,8 +120,8 @@
 
 
       <form method="post">
-        <button type="submit" class="btn-link" >
-          This is a link that sends a POST request
+        <button role="link" type="submit" id="no-evidence-link" class="btn-link" >
+          Continue without adding documents
         </button>
       </form>
 

--- a/test/controllers/EvidenceUploadController.test.ts
+++ b/test/controllers/EvidenceUploadController.test.ts
@@ -279,4 +279,31 @@ describe('EvidenceUploadController', () => {
                 });
         });
     });
+    describe('POST request: action=continue-without-upload', () => {
+        const NO_UPLOAD_ACTION = 'continue-without-upload';
+
+        it('should return 302 and redirect to check your appeals when no attachments present', async () => {
+
+            const app = createApp({ appeal: appealNoAttachments });
+
+            await request(app).post(EVIDENCE_UPLOAD_PAGE_URI)
+                .query('action=' + NO_UPLOAD_ACTION)
+                .expect(response => {
+                    expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                    expect(response.get('Location')).to.be.equal(CHECK_YOUR_APPEAL_PAGE_URI);
+                });
+        });
+
+        it('should return 302 and redirect to check your appeals when attachments present', async () => {
+
+            const app = createApp({ appeal: appealWithAttachments });
+
+            await request(app).post(EVIDENCE_UPLOAD_PAGE_URI)
+                .query('action=' + NO_UPLOAD_ACTION)
+                .expect(response => {
+                    expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                    expect(response.get('Location')).to.be.equal(CHECK_YOUR_APPEAL_PAGE_URI);
+                });
+        });
+    });
 });


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LFA-1280

### Change description

Using "Continue without adding documents" on "Add documents..." screen, takes the user to the check-answers screen.

If JavaScript is disabled, this does not save the file selected in the file browser.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
