### PR TITLE
Fix: update error message double quotes

### DIFF
--- a/src/controllers/EvidenceUploadController.ts
+++ b/src/controllers/EvidenceUploadController.ts
@@ -52,7 +52,7 @@ const continueButtonValidator: Validator = {
 
         if (!attachments || attachments.length === 0) {
             return new ValidationResult([new ValidationError('file',
-                'You must add a document or click “Continue without adding documents”')]);
+                'You must add a document or click \"Continue without adding documents\"')]);
         }
         return new ValidationResult([]);
     }

--- a/test/controllers/EvidenceUploadController.test.ts
+++ b/test/controllers/EvidenceUploadController.test.ts
@@ -131,8 +131,8 @@ describe('EvidenceUploadController', () => {
                 .query('?')
                 .expect(response => {
                     expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
-                    expect(response.text).to.contain('There is a problem')
-                        .and.to.contain('You must add a document or click “Continue without adding documents”');
+                    expect(response.text).to.contain('There is a problem').and
+                        .to.contain('You must add a document or click &quot;Continue without adding documents&quot;');
                 });
         });
     });


### PR DESCRIPTION
### JIRA link

N/A

### Change description

Requested by Richard:

- Basically, what I am seeing is the double quotes surrounding continue without adding documents are 66s (“) & 99s (”) for ours, whereas for Extensions, they are "

- but they are reporting as non-asscii characters. That would suggest that in older browsers, they may not render correctly


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
