### PR TITLE
feat: make configuration profiles optional

### DIFF
--- a/src/ApplicationFactory.ts
+++ b/src/ApplicationFactory.ts
@@ -4,12 +4,12 @@ import { InversifyExpressServer } from 'inversify-express-utils';
 
 import { createContainer } from 'app/ContainerFactory';
 import { defaultHandler, notFoundHandler } from 'app/middleware/ErrorHandler';
-import { getExpressAppConfig } from 'app/utils/ConfigLoader';
+import { createExpressConfigFunction } from 'app/utils/ExpressConfigFunctionFactory';
 
 export class ApplicationFactory {
     public static createInstance(container: Container = createContainer()): Application {
         const server = new InversifyExpressServer(container);
-        server.setConfig(getExpressAppConfig(__dirname));
+        server.setConfig(createExpressConfigFunction(__dirname));
 
         const application: Application = server.build();
         application.use(notFoundHandler, defaultHandler);

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = 'lfp-appeals-frontend';

--- a/src/ContainerFactory.ts
+++ b/src/ContainerFactory.ts
@@ -4,8 +4,8 @@ import { buildProviderModule } from 'inversify-binding-decorators';
 import IORedis from 'ioredis';
 import * as kafka from 'kafka-node';
 import * as util from 'util';
-import { APP_NAME } from './utils/ConfigLoader';
 
+import { APP_NAME } from 'app/Constants';
 import { AppealsService } from 'app/modules/appeals-service/AppealsService';
 import { EmailService } from 'app/modules/email-publisher/EmailService';
 import { Payload, Producer } from 'app/modules/email-publisher/producer/Producer';

--- a/src/middleware/Logger.ts
+++ b/src/middleware/Logger.ts
@@ -1,7 +1,7 @@
 import { createLogger } from 'ch-logging';
 import ApplicationLogger from 'ch-logging/lib/ApplicationLogger';
 
-import { APP_NAME } from 'app/utils/ConfigLoader';
+import { APP_NAME } from 'app/Constants';
 
 let logger: ApplicationLogger;
 

--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -1,13 +1,4 @@
-import bodyParser = require('body-parser');
-import { createLoggerMiddleware } from 'ch-logging';
-import cookieParser = require('cookie-parser');
 import * as dotenv from 'dotenv';
-import * as express from 'express';
-import * as nunjucks from 'nunjucks';
-import * as path from 'path';
-
-import { getEnv, getEnvOrThrow } from 'app/utils/EnvironmentUtils';
-import * as Paths from 'app/utils/Paths';
 
 const DEFAULT_ENV_FILE = `${__dirname}/../../.env`;
 
@@ -16,8 +7,6 @@ const checkFileExists = (config: dotenv.DotenvConfigOutput) => {
     else return config;
 };
 
-export const APP_NAME = 'lfp-appeals-frontend';
-
 export const loadEnvironmentVariablesFromFiles = () => {
     dotenv.config({ path: DEFAULT_ENV_FILE });
     if (process.env.NODE_ENV) {
@@ -25,47 +14,3 @@ export const loadEnvironmentVariablesFromFiles = () => {
         checkFileExists(dotenv.config({ path: envFilePath }));
     }
 };
-
-export const getExpressAppConfig = (directory: string) => (app: express.Application): void => {
-    app.use(Paths.ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend')));
-    app.use(Paths.ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend/govuk')));
-
-    app.use(bodyParser.json());
-    app.use(bodyParser.urlencoded({ extended: true }));
-    app.use(cookieParser());
-
-    const loggingMiddleware = createLoggerMiddleware(APP_NAME);
-    app.use(loggingMiddleware);
-
-    app.set('view engine', 'njk');
-    nunjucks.configure([
-        'dist/views',
-        'node_modules/govuk-frontend',
-        'node_modules/govuk-frontend/components',
-    ], {
-        autoescape: true,
-        express: app,
-    });
-
-    app.locals.paths = Paths;
-    app.locals.ui = {
-        createChangeLinkConfig: (uri: string, accessibleName: string) => {
-            return {
-                href: `${uri}?cm=1`,
-                text: 'Change',
-                visuallyHiddenText: accessibleName
-            };
-        }
-    };
-
-    app.locals.cdn = {
-        host: getEnvOrThrow('CDN_HOST')
-    };
-
-    const url = getEnv('PIWIK_URL');
-    const site = getEnv('PIWIK_SITE_ID');
-    if (url && site) {
-        app.locals.piwik = { url, site };
-    }
-};
-

--- a/src/utils/ConfigLoader.ts
+++ b/src/utils/ConfigLoader.ts
@@ -2,15 +2,10 @@ import * as dotenv from 'dotenv';
 
 const DEFAULT_ENV_FILE = `${__dirname}/../../.env`;
 
-const checkFileExists = (config: dotenv.DotenvConfigOutput) => {
-    if (config.error) throw config.error;
-    else return config;
-};
-
 export const loadEnvironmentVariablesFromFiles = () => {
     dotenv.config({ path: DEFAULT_ENV_FILE });
     if (process.env.NODE_ENV) {
         const envFilePath = `${__dirname}/../../.env.${process.env.NODE_ENV}`;
-        checkFileExists(dotenv.config({ path: envFilePath }));
+        dotenv.config({ path: envFilePath });
     }
 };

--- a/src/utils/ExpressConfigFunctionFactory.ts
+++ b/src/utils/ExpressConfigFunctionFactory.ts
@@ -1,0 +1,53 @@
+import bodyParser from 'body-parser';
+import { createLoggerMiddleware } from 'ch-logging/lib';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import nunjucks from 'nunjucks';
+import path from 'path';
+
+import { APP_NAME } from 'app/Constants';
+import { getEnv, getEnvOrThrow } from 'app/utils/EnvironmentUtils';
+import * as Paths from 'app/utils/Paths';
+
+export const createExpressConfigFunction = (directory: string) => (app: express.Application): void => {
+    app.use(Paths.ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend')));
+    app.use(Paths.ROOT_URI, express.static(path.join(directory, '/node_modules/govuk-frontend/govuk')));
+
+    app.use(bodyParser.json());
+    app.use(bodyParser.urlencoded({ extended: true }));
+    app.use(cookieParser());
+
+    const loggingMiddleware = createLoggerMiddleware(APP_NAME);
+    app.use(loggingMiddleware);
+
+    app.set('view engine', 'njk');
+    nunjucks.configure([
+        'dist/views',
+        'node_modules/govuk-frontend',
+        'node_modules/govuk-frontend/components',
+    ], {
+        autoescape: true,
+        express: app,
+    });
+
+    app.locals.paths = Paths;
+    app.locals.ui = {
+        createChangeLinkConfig: (uri: string, accessibleName: string) => {
+            return {
+                href: `${uri}?cm=1`,
+                text: 'Change',
+                visuallyHiddenText: accessibleName
+            };
+        }
+    };
+
+    app.locals.cdn = {
+        host: getEnvOrThrow('CDN_HOST')
+    };
+
+    const url = getEnv('PIWIK_URL');
+    const site = getEnv('PIWIK_SITE_ID');
+    if (url && site) {
+        app.locals.piwik = { url, site };
+    }
+};

--- a/test/middleware/ErrorHandler.test.ts
+++ b/test/middleware/ErrorHandler.test.ts
@@ -6,7 +6,7 @@ import { INTERNAL_SERVER_ERROR, NOT_FOUND } from 'http-status-codes';
 import request from 'supertest';
 
 import { defaultHandler, notFoundHandler } from 'app/middleware/ErrorHandler';
-import { getExpressAppConfig as configureApplication } from 'app/utils/ConfigLoader';
+import { createExpressConfigFunction as configureApplication } from 'app/utils/ExpressConfigFunctionFactory';
 
 const pageHeading = 'Sorry, there is a problem with the service';
 const FAKE_PAGE_URI = '/fake-page';

--- a/test/utils/ConfigLoader.test.ts
+++ b/test/utils/ConfigLoader.test.ts
@@ -1,0 +1,40 @@
+import assert from 'assert';
+import { expect } from 'chai';
+import crypto from 'crypto';
+import fs from 'fs';
+
+import { loadEnvironmentVariablesFromFiles } from 'app/utils/ConfigLoader';
+
+function withTemporaryProfileFile(profile: string, content: string, fn: () => void): void {
+    const path = `${__dirname}/../../.env.${profile}`;
+
+    fs.writeFileSync(path, content);
+    try {
+        fn();
+        fs.unlinkSync(path);
+    } catch (error) {
+        fs.unlinkSync(path);
+        throw error;
+    }
+}
+
+describe('ConfigLoader', () => {
+    beforeEach(() => {
+        process.env.NODE_ENV = crypto.randomBytes(8).toString('hex');
+    });
+
+    it('should load environment variables from existing profile file', () => {
+        withTemporaryProfileFile(process.env.NODE_ENV!, 'ENABLED=1', () => {
+            loadEnvironmentVariablesFromFiles();
+            expect(process.env.ENABLED).to.be.equal('1');
+        });
+    });
+
+    it('should ignore profile file that does not exist', () => {
+        try {
+            loadEnvironmentVariablesFromFiles();
+        } catch (e) {
+            assert.fail('Loading profile that does not exist should have succeeded');
+        }
+    });
+});


### PR DESCRIPTION
### JIRA link

None

### Change description

With this change application won't throw an error when configuration profile file is missing. In that case, cause file does not exist, environment variables won't be loaded and application will fail later during launch phase only if required configuration is missing.

I used an occasion to cleanup code and restore correct responsibilities split.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
