### PR TITLE
feat: add penalty reference to internal email builder

### DIFF
--- a/src/controllers/processors/InternalEmailFormActionProcessor.ts
+++ b/src/controllers/processors/InternalEmailFormActionProcessor.ts
@@ -24,6 +24,7 @@ function buildEmail(userProfile: IUserProfile, appeal: Appeal, baseURI: string):
             templateName: 'lfp-appeal-submission-internal',
             templateData: {
                 companyNumber: appeal.penaltyIdentifier.companyNumber,
+                penaltyReference: appeal.penaltyIdentifier.penaltyReference,
                 userProfile: {
                     email: userProfile.email
                 },

--- a/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
+++ b/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
@@ -35,7 +35,8 @@ describe('InternalEmailFormSubmissionProcessor', () => {
         const appealWithoutAttachments: Appeal = {
             id: 'abc',
             penaltyIdentifier: {
-                companyNumber: '12345678'
+                companyNumber: '12345678',
+                penaltyReference: 'PEN1A/12345677'
             } as PenaltyIdentifier,
             reasons: {
                 other: {
@@ -99,6 +100,7 @@ describe('InternalEmailFormSubmissionProcessor', () => {
                     templateName: 'lfp-appeal-submission-internal',
                     templateData: {
                         companyNumber: '12345678',
+                        penaltyReference: 'PEN1A/12345677',
                         userProfile: {
                             email: 'user@example.com'
                         },
@@ -143,6 +145,7 @@ describe('InternalEmailFormSubmissionProcessor', () => {
                     templateName: 'lfp-appeal-submission-internal',
                     templateData: {
                         companyNumber: '12345678',
+                        penaltyReference: 'PEN1A/12345677',
                         userProfile: {
                             email: 'user@example.com'
                         },


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LFA-1656


### Change description
Add 'Type' row for penalty reference number to internal emails

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
