### PR TITLE
fix: fixed issue with penalty numbers not being validated

### DIFF
--- a/src/controllers/validators/PenaltyDetailsValidator.ts
+++ b/src/controllers/validators/PenaltyDetailsValidator.ts
@@ -63,7 +63,7 @@ export class PenaltyDetailsValidator implements Validator {
         try {
 
             const modernPenaltyReferenceRegex: RegExp = /^([A-Z][0-9]{7}|[0-9]{9})$/;
-
+            const deprecatedPenaltyReferenceRegex: RegExp = /^PEN[1-2][A-Z]\/[A-Z0-9]{8}$/;
             const penalties: Resource<PenaltyList> =
                 await this.chSdk(new OAuth2(accessToken)).lateFilingPenalties.getPenalties(companyNumber);
 
@@ -72,6 +72,11 @@ export class PenaltyDetailsValidator implements Validator {
             }
 
             let items: Penalty[] = penalties.resource.items.filter(penalty => penalty.type === 'penalty');
+
+            if (!deprecatedPenaltyReferenceRegex.test(penaltyReference) &&
+                !modernPenaltyReferenceRegex.test(penaltyReference)) {
+                return this.createValidationResultWithErrors();
+            }
 
             if (modernPenaltyReferenceRegex.test(penaltyReference)) {
                 items = items.filter(penalty => penalty.id === penaltyReference);

--- a/test/utils/validation/PenaltyDetailsValidator.test.ts
+++ b/test/utils/validation/PenaltyDetailsValidator.test.ts
@@ -174,6 +174,33 @@ describe('PenaltyDetailsValidator', () => {
 
     });
 
+    it('should return validation errors when the penalty reference is in the wrong format', () => {
+        const penaltyReferences = [
+            `PEN11A/${companyNumber}`,
+            `PEN1B/0000000000123`,
+            `abcd`
+        ];
+        const apiResponse = {
+            httpStatusCode: 200,
+            resource: {
+                items: [
+                    {
+                        id: 'A0000000',
+                        type: 'penalty',
+                        madeUpDate: '2020-10-10',
+                        transactionDate: '2020-11-10'
+                    } as Penalty
+                ]
+            } as PenaltyList
+        };
+
+        penaltyReferences.forEach(async penaltyReference => {
+            const penaltyDetailsValidator = new PenaltyDetailsValidator(createSDK(apiResponse));
+            const results = await penaltyDetailsValidator.validate(getRequest(penaltyReference));
+            expect(results.errors.length).to.equal(2);
+        });
+    });
+
     it('should return no validation errors and add penalty to request body for modern PR numbers', async () => {
 
         const penaltyReferences: string[] = ['A0000001', 'A0000002'];
@@ -221,12 +248,17 @@ describe('PenaltyDetailsValidator', () => {
 
     });
 
-    it('should return no validation errors and add penalty to request body for deprecated PR numbers', async () => {
+    it('should return no validation errors and add penalty to request body for deprecated PR numbers', () => {
 
-        const penaltyReferences: string[] = ['A0000001', 'A0000002'];
+        const penaltyReferences = [
+            `PEN1A/${companyNumber}`,
+            `PEN1B/${companyNumber}`,
+            `PEN0Z/00000000`
+        ];
+
         const items = [
             {
-                id: penaltyReferences[0],
+                id: 'A0000001',
                 type: 'penalty',
                 madeUpDate: '2020-10-10',
                 transactionDate: '2020-11-10'
@@ -234,7 +266,7 @@ describe('PenaltyDetailsValidator', () => {
         ];
         const mappedItems = [
             {
-                id: penaltyReferences[0],
+                id: 'A0000001',
                 type: 'penalty',
                 madeUpDate: '10 October 2020',
                 transactionDate: '10 November 2020'
@@ -246,16 +278,17 @@ describe('PenaltyDetailsValidator', () => {
                 items
             } as PenaltyList
         };
-        const oldPenaltyReference = `PEN1A/${companyNumber}`;
 
-        const penaltyDetailsValidatorOld = new PenaltyDetailsValidator(createSDK(apiResponse));
+        penaltyReferences.forEach(async penaltyReference => {
 
-        const oldPenaltyRequest: Request = getRequest(oldPenaltyReference);
+            const penaltyDetailsValidatorOld = new PenaltyDetailsValidator(createSDK(apiResponse));
+            const oldPenaltyRequest: Request = getRequest(penaltyReference);
 
-        const oldPenaltyReferenceResult = await penaltyDetailsValidatorOld.validate(oldPenaltyRequest);
+            const oldPenaltyReferenceResult = await penaltyDetailsValidatorOld.validate(oldPenaltyRequest);
 
-        expect(oldPenaltyReferenceResult.errors.length).to.equal(0);
-        expect(oldPenaltyRequest.body.penaltyList.items).to.deep.equal(mappedItems);
+            expect(oldPenaltyReferenceResult.errors.length).to.equal(0);
+            expect(oldPenaltyRequest.body.penaltyList.items).to.deep.equal(mappedItems);
+        });
 
     });
 


### PR DESCRIPTION
### JIRA link
N/A


### Change description
Fixed issue where an invalid penalty reference would allow the user through to the summary screen. This was caused by not checking whether the penalty reference number was in the old format. Now both the modern format and the old format are checked which means that any PR that doesn't comply with those formats will result in validation error.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
