### PR TITLE
bugfix: sanitise company numbers before mongo and E5 lookups

### DIFF
--- a/src/controllers/processors/CompanyNameProcessor.ts
+++ b/src/controllers/processors/CompanyNameProcessor.ts
@@ -42,7 +42,7 @@ export class CompanyNameProcessor implements FormActionProcessor {
             throw COMPANY_NUMBER_UNDEFINED_ERROR;
         }
 
-        const sanitizedCompanyNumber = sanitizeCompany(companyNumber);
+        const sanitizedCompanyNumber: string = sanitizeCompany(companyNumber);
 
         const profile: Resource<CompanyProfile> = await this
             .chSdk(new OAuth2(token))

--- a/src/controllers/validators/PenaltyDetailsValidator.ts
+++ b/src/controllers/validators/PenaltyDetailsValidator.ts
@@ -17,6 +17,7 @@ import { CompaniesHouseSDK, OAuth2 } from 'app/modules/Types';
 import { SchemaValidator } from 'app/utils/validation/SchemaValidator';
 import { ValidationError } from 'app/utils/validation/ValidationError';
 import { ValidationResult } from 'app/utils/validation/ValidationResult';
+import { sanitizeCompany } from 'app/utils/CompanyNumberSanitizer';
 
 @provide(PenaltyDetailsValidator)
 export class PenaltyDetailsValidator implements Validator {
@@ -65,7 +66,8 @@ export class PenaltyDetailsValidator implements Validator {
             const modernPenaltyReferenceRegex: RegExp = /^([A-Z][0-9]{7}|[0-9]{9})$/;
 
             const penalties: Resource<PenaltyList> =
-                await this.chSdk(new OAuth2(accessToken)).lateFilingPenalties.getPenalties(companyNumber);
+                await this.chSdk(new OAuth2(accessToken))
+                    .lateFilingPenalties.getPenalties(sanitizeCompany(companyNumber));
 
             if (penalties.httpStatusCode !== OK || !penalties.resource) {
                 throw new Error(`PenaltyDetailsValidator: failed to get penalties from pay API with status code ${penalties.httpStatusCode} with access token ${accessToken}`);

--- a/src/controllers/validators/PenaltyDetailsValidator.ts
+++ b/src/controllers/validators/PenaltyDetailsValidator.ts
@@ -56,6 +56,8 @@ export class PenaltyDetailsValidator implements Validator {
 
         const companyNumber: string = (request.body as PenaltyIdentifier).companyNumber;
 
+        const sanitizedCompanyNumber: string = sanitizeCompany(companyNumber);
+
         const penaltyReference: string = (request.body as PenaltyIdentifier).penaltyReference;
 
         const mapErrorMessage = 'Cannot read property \'map\' of null';
@@ -67,7 +69,7 @@ export class PenaltyDetailsValidator implements Validator {
 
             const penalties: Resource<PenaltyList> =
                 await this.chSdk(new OAuth2(accessToken))
-                    .lateFilingPenalties.getPenalties(sanitizeCompany(companyNumber));
+                    .lateFilingPenalties.getPenalties(sanitizedCompanyNumber);
 
             if (penalties.httpStatusCode !== OK || !penalties.resource) {
                 throw new Error(`PenaltyDetailsValidator: failed to get penalties from pay API with status code ${penalties.httpStatusCode} with access token ${accessToken}`);
@@ -82,7 +84,7 @@ export class PenaltyDetailsValidator implements Validator {
             }
 
             if (!items || items.length === 0) {
-                loggerInstance().error(`${PenaltyDetailsValidator.name}: No penalties for ${companyNumber} match the reference number ${penaltyReference}`);
+                loggerInstance().error(`${PenaltyDetailsValidator.name}: No penalties for ${sanitizedCompanyNumber} match the reference number ${penaltyReference}`);
                 return this.createValidationResultWithErrors();
             }
 


### PR DESCRIPTION
### JIRA link

N/A

### Change description

Company number SC10 should be treated as SC000010 when searching for company names or validating with E5

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
