### PR TITLE
fix: fixed validation errors not showing when failing to get penalties

### DIFF
--- a/src/controllers/validators/PenaltyDetailsValidator.ts
+++ b/src/controllers/validators/PenaltyDetailsValidator.ts
@@ -27,8 +27,9 @@ import { ValidationResult } from 'app/utils/validation/ValidationResult';
 export class PenaltyDetailsValidator implements Validator {
 
     public static COMPANY_NUMBER_VALIDATION_ERROR: ValidationError = new ValidationError('companyNumber', 'Check that you’ve entered the correct company number');
-    public static PENALTY_REFERENCE_VALIDATION_ERROR: ValidationError = new ValidationError('penaltyReference', 'Check that you’ve entered the correct reference number');
+    public static PENALTY_REFERENCE_VALIDATION_ERROR: ValidationError = new ValidationError('userInputPenaltyReference', 'Check that you’ve entered the correct reference number');
     public static MULTIPLE_PENALTIES_FOUND_ERROR: Error = new Error(`Multiple penalties found. This is currently unsupported`);
+
     constructor(@inject(CompaniesHouseSDK) readonly chSdk: CompaniesHouseSDK) { }
 
 
@@ -53,7 +54,7 @@ export class PenaltyDetailsValidator implements Validator {
         }
 
         const appData: ApplicationData = session.getExtraData<ApplicationData>(APPLICATION_DATA_KEY)
-            ||{ appeal: {} as Appeal, navigation: { permissions: [] } } as ApplicationData;
+            || { appeal: {} as Appeal, navigation: { permissions: [] } } as ApplicationData;
 
         const signInInfo: ISignInInfo | undefined = session.get<ISignInInfo>(SessionKey.SignInInfo);
 


### PR DESCRIPTION
### JIRA link
N/A

### Change description
Fixed bug where validation errors in the details screen wouldn't both show up when the service failed to get the late filling penalties from the api.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
