### PR TITLE
feat: add prompt download url to attachment object

### DIFF
--- a/src/controllers/EvidenceUploadController.ts
+++ b/src/controllers/EvidenceUploadController.ts
@@ -19,10 +19,12 @@ import { getEnvOrThrow } from 'app/utils/EnvironmentUtils';
 import { parseFormData } from 'app/utils/MultipartFormDataParser';
 import {
     CHECK_YOUR_APPEAL_PAGE_URI,
+    DOWNLOAD_FILE_PAGE_URI,
     EVIDENCE_QUESTION_URI,
     EVIDENCE_REMOVAL_PAGE_URI,
     EVIDENCE_UPLOAD_PAGE_URI
 } from 'app/utils/Paths';
+import { newUriFactory } from 'app/utils/UriFactory';
 import { Navigation } from 'app/utils/navigation/navigation';
 import { ValidationError } from 'app/utils/validation/ValidationError';
 import { ValidationResult } from 'app/utils/validation/ValidationResult';
@@ -148,8 +150,15 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
                         }
                     }
 
+                    const downloadBaseURI: string = newUriFactory(request)
+                        .createAbsoluteUri(DOWNLOAD_FILE_PAGE_URI);
+
                     appeal.reasons.other.attachments = [...appeal.reasons.other.attachments || [], {
-                        id, name: request.file.originalname, contentType: request.file.mimetype, size: request.file.size
+                        id,
+                        name: request.file.originalname,
+                        contentType: request.file.mimetype,
+                        size: request.file.size,
+                        url: `${downloadBaseURI}/prompt/${id}?c=${appeal.penaltyIdentifier.companyNumber}`
                     }];
 
                     await that.persistSession();

--- a/src/controllers/processors/InternalEmailFormActionProcessor.ts
+++ b/src/controllers/processors/InternalEmailFormActionProcessor.ts
@@ -34,7 +34,7 @@ function buildEmail(userProfile: IUserProfile, appeal: Appeal): Email {
                         attachments: appeal.reasons.other.attachments?.map(attachment => {
                             return {
                                 name: attachment.name,
-                                url: attachment.url + `&a=${appeal.id}`
+                                url: `${attachment.url}&a=${appeal.id}`
                             };
                         })
                     }

--- a/src/models/Attachment.ts
+++ b/src/models/Attachment.ts
@@ -3,4 +3,5 @@ export interface Attachment {
     name: string;
     contentType: string;
     size: number;
+    url: string;
 }

--- a/test/controllers/EvidenceUploadController.test.ts
+++ b/test/controllers/EvidenceUploadController.test.ts
@@ -53,11 +53,13 @@ const appealWithAttachments: Appeal = {
             attachments: [
                 {
                     id: '1',
-                    name: 'some-file.jpeg'
+                    name: 'some-file.jpeg',
+                    url: 'http://localhost/appeal-a-penalty/download/prompt/1?c=00345567'
                 } as Attachment,
                 {
                     id: '2',
-                    name: 'another-file.jpeg'
+                    name: 'another-file.jpeg',
+                    url: 'http://localhost/appeal-a-penalty/download/prompt/2?c=00345567'
                 } as Attachment
             ]
         }

--- a/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
+++ b/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
@@ -133,7 +133,8 @@ describe('InternalEmailFormSubmissionProcessor', () => {
                                 id: '123',
                                 name: 'evidence.png',
                                 contentType: 'image/png',
-                                size: 100
+                                size: 100,
+                                url: 'http://localhost/appeal-a-penalty/download/prompt/123?c=12345678'
                             }
                         ]
                     }
@@ -159,7 +160,7 @@ describe('InternalEmailFormSubmissionProcessor', () => {
                                 attachments: [
                                     {
                                         name: 'evidence.png',
-                                        url: `http://localhost/appeal-a-penalty/download/prompt/123?a=abc&c=12345678`
+                                        url: `http://localhost/appeal-a-penalty/download/prompt/123?c=12345678&a=abc`
                                     }
                                 ]
                             }

--- a/test/models/AppDataFactory.ts
+++ b/test/models/AppDataFactory.ts
@@ -11,13 +11,15 @@ export function createDefaultAttachments(): Attachment[] {
             id: '123',
             name: 'some-file.jpeg',
             size: 1000,
-            contentType: 'image/jpeg'
+            contentType: 'image/jpeg',
+            url: 'http://localhost/appeal-a-penalty/download/prompt/123?c=00345567'
         },
         {
             id: '456',
             name: 'another-file.txt',
             contentType: 'text/plain',
-            size: 200
+            size: 200,
+            url: 'http://localhost/appeal-a-penalty/download/prompt/456?c=00345567'
         }
     ];
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LFA-1595


### Change description
* Added additional property `url` to `Attachment` object
* After file upload, attachment url is saved to the session
* Updated `InternalEmailFormActionProcessor.ts` to use attachment url in session when generating email body
* Appeal ID will be appended to the attachment url (for enabling download permissions) after appeal entry is stored in Mongo Db (requires change in Appeals API - follow up PR)

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
