### PR TITLE
fix: fixed bug when using old pr on company with 1 penalty

### DIFF
--- a/src/controllers/BaseController.ts
+++ b/src/controllers/BaseController.ts
@@ -198,10 +198,10 @@ export class BaseController<FORM> extends BaseAsyncHttpController {
                     const applicationData: ApplicationData = session
                         .getExtraData(APPLICATION_DATA_KEY) || {} as ApplicationData;
 
-                    session.setExtraData(APPLICATION_DATA_KEY, applicationData);
-
                     applicationData.appeal = that
                         .prepareSessionModelPriorSave(applicationData.appeal || {}, request.body);
+
+                    session.setExtraData(APPLICATION_DATA_KEY, applicationData);
 
                     await that.persistSession();
                 }

--- a/src/controllers/PenaltyDetailsController.ts
+++ b/src/controllers/PenaltyDetailsController.ts
@@ -51,7 +51,12 @@ export class PenaltyDetailsController extends SafeNavigationBaseController<Penal
     }
 
     protected prepareSessionModelPriorSave(appeal: Appeal, value: any): Appeal {
+
+        if (value.penaltyList.items.length === 1) {
+            value.penaltyReference = value.penaltyList.items[0].id;
+        }
         appeal.penaltyIdentifier = value;
+
         loggerInstance()
             .debug(`${PenaltyDetailsController.name} - prepareSessionModelPriorSave: ${JSON.stringify(appeal)}`);
         return appeal;

--- a/src/controllers/ReviewPenaltyController.ts
+++ b/src/controllers/ReviewPenaltyController.ts
@@ -43,13 +43,7 @@ export class ReviewPenaltyController extends SafeNavigationBaseController<Penalt
             throw new Error(ReviewPenaltyController.PENALTY_EXPECTED_ERROR);
         }
 
-        let penaltyReference: string | undefined;
-
-        if (penaltyList.items.length === 1) {
-            penaltyReference = appeal.penaltyIdentifier.userInputPenaltyReference;
-        } else {
-            penaltyReference = appeal.penaltyIdentifier.penaltyReference;
-        }
+        const penaltyReference: string | undefined = appeal.penaltyIdentifier.penaltyReference;
 
         if (!penaltyReference) {
             throw new Error(ReviewPenaltyController.PENALTY_IDENTIFIER_EXPECTED_ERROR);

--- a/test/controllers/PenaltyDetailsController.test.ts
+++ b/test/controllers/PenaltyDetailsController.test.ts
@@ -63,7 +63,11 @@ describe('PenaltyDetailsController', () => {
             const appeal = {
                 penaltyIdentifier: {
                     companyNumber: 'SC123123',
-                    userInputPenaltyReference: 'A12345678'
+                    userInputPenaltyReference: 'A12345678',
+                    penaltyReference: 'A12345678',
+                    penaltyList: {
+                        items: [{ id: 'A12345678' }]
+                    }
                 }
             } as Appeal;
 

--- a/test/utils/validation/PenaltyDetailsValidator.test.ts
+++ b/test/utils/validation/PenaltyDetailsValidator.test.ts
@@ -34,7 +34,8 @@ describe('PenaltyDetailsValidator', () => {
         return {
             body: {
                 companyNumber,
-                userInputPenaltyReference
+                userInputPenaltyReference,
+                penaltyReference: userInputPenaltyReference
             },
             session
         } as Request;
@@ -255,7 +256,7 @@ describe('PenaltyDetailsValidator', () => {
 
             expect(oldPenaltyReferenceResult.errors.length).to.equal(0);
             expect(oldPenaltyRequest.body.penaltyList.items[0]).to.deep.equal(mappedItems);
-            expect(oldPenaltyRequest.body.penaltyReference).to.equal(mappedItems[0].id);
+            expect(oldPenaltyRequest.body.userInputPenaltyReference).to.equal(mappedItems[0].id);
         });
 
     });


### PR DESCRIPTION
### JIRA link
N/A


### Change description
A bug was spotted where a user would input an old penalty reference and if the company had only one penalty list, it would fail because we weren't replacing the penaltyReference field correctly.


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
