### PR TITLE
feat: session cleanup after submission

### DIFF
--- a/src/controllers/CheckYourAppealController.ts
+++ b/src/controllers/CheckYourAppealController.ts
@@ -6,6 +6,7 @@ import { controller } from 'inversify-express-utils';
 import { SafeNavigationBaseController } from 'app/controllers/SafeNavigationBaseController';
 import { AppealStorageFormActionProcessor } from 'app/controllers/processors/AppealStorageFormActionProcessor';
 import { InternalEmailFormActionProcessor } from 'app/controllers/processors/InternalEmailFormActionProcessor';
+import { SessionCleanupProcessor } from 'app/controllers/processors/SessionCleanupProcessor';
 import { UserEmailFormActionProcessor } from 'app/controllers/processors/UserEmailFormActionProcessor';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { loggerInstance } from 'app/middleware/Logger';
@@ -39,7 +40,7 @@ const navigation = {
 export class CheckYourAppealController extends SafeNavigationBaseController<any> {
     constructor() {
         super(template, navigation, undefined, undefined, [AppealStorageFormActionProcessor,
-            InternalEmailFormActionProcessor, UserEmailFormActionProcessor]);
+            InternalEmailFormActionProcessor, UserEmailFormActionProcessor, SessionCleanupProcessor]);
         // tslint:disable-next-line: forin
         for (const region in Region) {
             getEnvOrThrow(`${region}_TEAM_EMAIL`);

--- a/src/controllers/ConfirmationController.ts
+++ b/src/controllers/ConfirmationController.ts
@@ -9,6 +9,7 @@ import { UserEmailFormActionProcessor } from 'app/controllers/processors/UserEma
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { loggerInstance } from 'app/middleware/Logger';
 import { Appeal } from 'app/models/Appeal';
+import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { CHECK_YOUR_APPEAL_PAGE_URI, CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
 
 const template = 'confirmation';
@@ -33,12 +34,19 @@ export class ConfirmationController extends SafeNavigationBaseController<any> {
 
         const userProfile: IUserProfile | undefined = session.get<ISignInInfo>(SessionKey.SignInInfo)?.user_profile;
 
-        if (!userProfile){
+        if (!userProfile) {
             throw new Error('User profile was expected in session but none found');
         }
 
+        const appealData: Appeal | undefined = session
+            .getExtraData<ApplicationData>(APPLICATION_DATA_KEY)?.submittedAppeal;
+
+        if (!appealData) {
+            throw new Error('Appeal data was expected in session but none found');
+        }
+
         const model = {
-            ...super.prepareViewModelFromSession(session),
+            ...appealData,
             userProfile
         };
         loggerInstance()

--- a/src/controllers/processors/SessionCleanupProcessor.ts
+++ b/src/controllers/processors/SessionCleanupProcessor.ts
@@ -3,6 +3,7 @@ import { Request } from 'express';
 import { provide } from 'inversify-binding-decorators';
 
 import { FormActionProcessor } from 'app/controllers/processors/FormActionProcessor';
+import { loggerInstance } from 'app/middleware/Logger';
 import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { APPLICATION_DATA_UNDEFINED, SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
 import { CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
@@ -31,6 +32,8 @@ export class SessionCleanupProcessor implements FormActionProcessor {
         appData.navigation.permissions = [CONFIRMATION_PAGE_URI];
 
         session.setExtraData(APPLICATION_DATA_KEY, appData);
+
+        loggerInstance().info(`${SessionCleanupProcessor.name} - Session data cleared`);
 
         return Promise.resolve();
     }

--- a/src/controllers/processors/SessionCleanupProcessor.ts
+++ b/src/controllers/processors/SessionCleanupProcessor.ts
@@ -1,0 +1,38 @@
+import { Session } from 'ch-node-session-handler';
+import { Request } from 'express';
+import { provide } from 'inversify-binding-decorators';
+
+import { FormActionProcessor } from 'app/controllers/processors/FormActionProcessor';
+import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
+import { APPLICATION_DATA_UNDEFINED, SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
+import { CONFIRMATION_PAGE_URI } from 'app/utils/Paths';
+
+@provide(SessionCleanupProcessor)
+export class SessionCleanupProcessor implements FormActionProcessor {
+
+    public async process(req: Request): Promise<void> {
+
+        const session: Session | undefined = req.session;
+
+        if (!session) {
+            throw SESSION_NOT_FOUND_ERROR;
+        }
+
+        const appData: ApplicationData | undefined = session.getExtraData<ApplicationData>(APPLICATION_DATA_KEY);
+
+        if (!appData) {
+            throw APPLICATION_DATA_UNDEFINED;
+        }
+
+        appData.submittedAppeal = appData.appeal;
+
+        delete appData.appeal;
+
+        appData.navigation.permissions = [CONFIRMATION_PAGE_URI];
+
+        session.setExtraData(APPLICATION_DATA_KEY, appData);
+
+        return Promise.resolve();
+    }
+
+}

--- a/src/models/ApplicationData.ts
+++ b/src/models/ApplicationData.ts
@@ -7,4 +7,5 @@ export const APPLICATION_DATA_KEY = 'appeals';
 export interface ApplicationData {
     appeal: Appeal;
     navigation: Navigation;
+    submittedAppeal?: Appeal;
 }

--- a/test/controllers/ConfirmationController.test.ts
+++ b/test/controllers/ConfirmationController.test.ts
@@ -27,7 +27,7 @@ describe('ConfirmationController', () => {
         } as Appeal;
 
         const applicationData = {
-            appeal,
+            submittedAppeal: appeal,
             navigation
         } as ApplicationData;
 


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LFA-1641


### Change description
After checking the penalty details the user is not able to go back to change them. The only permitted route is to go back to the beginning to the journey by pressing the govuk icon.
**Note:** The user can still access the confirmation screen 
![image](https://user-images.githubusercontent.com/54070318/85291762-cca7df00-b492-11ea-9124-6867a58d8732.png)


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
