### PR TITLE
fix: CompanyAuthMiddleware - add redirect to penalty details page when no appeal in session

### DIFF
--- a/src/middleware/CompanyAuthMiddleware.ts
+++ b/src/middleware/CompanyAuthMiddleware.ts
@@ -13,6 +13,7 @@ import { CompanyAuthConfig } from 'app/models/CompanyAuthConfig';
 import { Mutable } from 'app/models/Mutable';
 import { SessionStoreConfig } from 'app/models/SessionConfig';
 import { JwtEncryptionService } from 'app/modules/jwt-encryption-service/JwtEncryptionService';
+import { PENALTY_DETAILS_PAGE_URI } from 'app/utils/Paths';
 
 const oathScopePrefix: string = 'https://api.companieshouse.gov.uk/company/';
 
@@ -41,7 +42,8 @@ export class CompanyAuthMiddleware extends BaseMiddleware {
 
         const appeal: Appeal = applicationData.appeal;
         if (!appeal) {
-            return next(new Error('Appeal data not found'));
+            loggerInstance().info(`CompanyAuthMiddleware: Appeal data not found in session, redirecting to ${PENALTY_DETAILS_PAGE_URI}`);
+            return res.redirect(PENALTY_DETAILS_PAGE_URI);
         }
 
         const companyNumber: string = appeal.penaltyIdentifier.companyNumber;

--- a/test/controllers/EvidenceUploadController.test.ts
+++ b/test/controllers/EvidenceUploadController.test.ts
@@ -17,7 +17,7 @@ import { Attachment } from 'app/models/Attachment';
 import { Navigation } from 'app/models/Navigation';
 import { FileTransferService } from 'app/modules/file-transfer-service/FileTransferService';
 import { UnsupportedFileTypeError } from 'app/modules/file-transfer-service/errors';
-import { CHECK_YOUR_APPEAL_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI } from 'app/utils/Paths';
+import { CHECK_YOUR_APPEAL_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI, PENALTY_DETAILS_PAGE_URI } from 'app/utils/Paths';
 
 import { createApp } from 'test/ApplicationFactory';
 import { createSubstituteOf } from 'test/SubstituteFactory';
@@ -261,7 +261,7 @@ describe('EvidenceUploadController', () => {
             fileTransferService.received().upload(Arg.any(), FILE_NAME);
         });
 
-        it('should return 500 if no appeal in session', async () => {
+        it('should redirect to penalty details page if no appeal in session', async () => {
 
             const app = createApp({ appeal: undefined });
 
@@ -269,8 +269,8 @@ describe('EvidenceUploadController', () => {
                 .query('action=' + UPLOAD_FILE_ACTION)
                 .attach('file', buffer, FILE_NAME)
                 .expect(response => {
-                    expect(response.status).to.be.equal(INTERNAL_SERVER_ERROR);
-                    expect(response.text).to.contain('Sorry, there is a problem with the service');
+                    expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                    expect(response.get('Location')).to.be.equal(PENALTY_DETAILS_PAGE_URI);
                 });
         });
 

--- a/test/middleware/CompanyAuthMiddleware.test.ts
+++ b/test/middleware/CompanyAuthMiddleware.test.ts
@@ -98,11 +98,9 @@ describe('Company Authentication Middleware', () => {
         const response = createSubstituteOf<Response>();
         const request = getRequestSubstitute({}, '');
 
-        const startingWithRedirectUrl = (redirect : string) => redirect.startsWith(PENALTY_DETAILS_PAGE_URI);
-
         await companyAuthMiddleware.handler(request, response, nextFunction);
         nextFunction.didNotReceive();
-        response.received(1).redirect(Arg.is(startingWithRedirectUrl));
+        response.received(1).redirect(Arg.is(arg => arg === PENALTY_DETAILS_PAGE_URI));
 
     });
 

--- a/test/middleware/CompanyAuthMiddleware.test.ts
+++ b/test/middleware/CompanyAuthMiddleware.test.ts
@@ -14,6 +14,7 @@ import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationDat
 import { CompanyAuthConfig } from 'app/models/CompanyAuthConfig';
 import { JwtEncryptionService } from 'app/modules/jwt-encryption-service/JwtEncryptionService';
 import { SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
+import { PENALTY_DETAILS_PAGE_URI } from 'app/utils/Paths';
 
 import { createSubstituteOf } from 'test/SubstituteFactory';
 
@@ -75,6 +76,34 @@ describe('Company Authentication Middleware', () => {
         } catch (err) {
             expect(err).to.equal(SESSION_NOT_FOUND_ERROR);
         }
+
+    });
+
+    it('should redirect to penalty details page no appeal data in session', async () => {
+
+        const encryptionService = createSubstituteOf<JwtEncryptionService>(service => {
+            service.encrypt(Arg.any()).resolves('');
+        });
+
+        const sessionStore = Substitute.for<SessionStore>();
+        const companyAuthMiddleware = new CompanyAuthMiddleware(
+            sessionStore,
+            encryptionService,
+            companyAuthConfig,
+            sessionStoreForAuthConfig,
+            featureFlag
+        );
+
+        const nextFunction = createSubstituteOf<NextFunction>();
+        const response = createSubstituteOf<Response>();
+        const request = getRequestSubstitute({}, '');
+
+        const startingWithRedirectUrl = (redirect : string) => redirect.startsWith(PENALTY_DETAILS_PAGE_URI);
+
+        await companyAuthMiddleware.handler(request, response, nextFunction);
+        nextFunction.didNotReceive();
+        response.received(1).redirect(Arg.is(startingWithRedirectUrl));
+
 
     });
 

--- a/test/middleware/CompanyAuthMiddleware.test.ts
+++ b/test/middleware/CompanyAuthMiddleware.test.ts
@@ -104,7 +104,6 @@ describe('Company Authentication Middleware', () => {
         nextFunction.didNotReceive();
         response.received(1).redirect(Arg.is(startingWithRedirectUrl));
 
-
     });
 
     it('should call next with a feature flag is set to false', async () => {


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/LFA-1295


### Change description
On the CompanyAuthMiddleware, which is applied to most pages in the journey, added a redirect to the penalty details page when there is no appeal data in the session


### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
