### PR TITLE
fix: Add error banner to Choose Reason page

### DIFF
--- a/src/views/choose-appeal-reason.njk
+++ b/src/views/choose-appeal-reason.njk
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block backLink %}
-    {{ 
+  {{ 
     govukBackLink({
       text: 'Back',
       href: ''
@@ -19,48 +19,48 @@
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            {{
-                govukErrorSummary ({
-                    titleText: 'There is a problem with the details you gave us',
-                    errorList: validationResult.errors
-                }) if validationResult and validationResult.errors.length > 0
-            }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{
+        govukErrorSummary ({
+          titleText: 'There is a problem with the details you gave us',
+          errorList: validationResult.errors
+        }) if validationResult and validationResult.errors.length > 0
+      }}
 
-            <form method="post" id="choose-reasons-form">
-                {{ 
-                    govukRadios({
-                        idPrefix: 'choose-reason',
-                        name: 'reason',
-                        fieldset: {
-                            describedBy: 'choose-reason-hint',
-                            legend: {
-                                text: 'Why are you appealing this penalty?',
-                                isPageHeading: true,
-                                classes: 'govuk-fieldset__legend--xl'
-                            }
-                        },
-                        hint: {
-                            text: 'You can add more reasons later'
-                        },
-                        errorMessage: validationResult.getErrorForField('reason') if validationResult,
-                        items: [
-                            { value: 'illness', text: 'Illness and health issues' },
-                            { value: 'other', text: 'I’m appealing for another reason' }
-                        ]
-                    })
-                }}
+      <form method="post" id="choose-reasons-form">
+        {{ 
+          govukRadios({
+            idPrefix: 'choose-reason',
+            name: 'reason',
+            fieldset: {
+              describedBy: 'choose-reason-hint',
+              legend: {
+                text: 'Why are you appealing this penalty?',
+                isPageHeading: true,
+                classes: 'govuk-fieldset__legend--xl'
+              }
+            },
+            hint: {
+              text: 'You can add more reasons later'
+            },
+            errorMessage: validationResult.getErrorForField('reason') if validationResult,
+            items: [
+              { value: 'illness', text: 'Illness and health issues' },
+              { value: 'other', text: 'I’m appealing for another reason' }
+            ]
+          })
+        }}
 
-                {{ 
-                    govukButton({
-                        text: 'Continue',
-                        attributes: {
-                            id: 'submit'
-                        }
-                    }) 
-                }}
-            </form>
-        </div>
+        {{ 
+          govukButton({
+            text: 'Continue',
+            attributes: {
+              id: 'submit'
+            }
+          }) 
+        }}
+      </form>
     </div>
+  </div>
 {% endblock %}

--- a/src/views/choose-appeal-reason.njk
+++ b/src/views/choose-appeal-reason.njk
@@ -1,15 +1,16 @@
 {% extends 'layout.njk' %}
 
-{% from 'govuk/components/back-link/macro.njk'     import govukBackLink %}
-{% from 'govuk/components/button/macro.njk' import govukButton %}
-{% from 'govuk/components/radios/macro.njk' import govukRadios %}
+{% from 'govuk/components/back-link/macro.njk'      import govukBackLink %}
+{% from 'govuk/components/error-summary/macro.njk'  import govukErrorSummary %}
+{% from 'govuk/components/button/macro.njk'         import govukButton %}
+{% from 'govuk/components/radios/macro.njk'         import govukRadios %}
 
 {% block pageTitle %}
   You must tell us the reason for the appeal
 {% endblock %}
 
 {% block backLink %}
-  {{ 
+    {{ 
     govukBackLink({
       text: 'Back',
       href: ''
@@ -18,45 +19,48 @@
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-width-container">
-        <main role="main" class="govuk-main-wrapper">
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
-                    <form method="post" id="choose-reasons-form">
-                        {{ 
-                            govukRadios({
-                                idPrefix: 'choose-reason',
-                                name: 'reason',
-                                fieldset: {
-                                    describedBy: 'choose-reason-hint',
-                                    legend: {
-                                        text: 'Why are you appealing this penalty?',
-                                        isPageHeading: true,
-                                        classes: 'govuk-fieldset__legend--xl'
-                                    }
-                                },
-                                hint: {
-                                    text: 'You can add more reasons later'
-                                },
-                                errorMessage: validationResult.getErrorForField('reason') if validationResult,
-                                items: [
-                                    { value: 'illness', text: 'Illness and health issues' },
-                                    { value: 'other', text: 'I’m appealing for another reason' }
-                                ]
-                            })
-                        }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{
+                govukErrorSummary ({
+                    titleText: 'There is a problem with the details you gave us',
+                    errorList: validationResult.errors
+                }) if validationResult and validationResult.errors.length > 0
+            }}
 
-                        {{ 
-                            govukButton({
-                                text: 'Continue',
-                                attributes: {
-                                    id: 'submit'
-                                }
-                            }) 
-                        }}
-                    </form>
-                </div>
-            </div>
-        </main>
+            <form method="post" id="choose-reasons-form">
+                {{ 
+                    govukRadios({
+                        idPrefix: 'choose-reason',
+                        name: 'reason',
+                        fieldset: {
+                            describedBy: 'choose-reason-hint',
+                            legend: {
+                                text: 'Why are you appealing this penalty?',
+                                isPageHeading: true,
+                                classes: 'govuk-fieldset__legend--xl'
+                            }
+                        },
+                        hint: {
+                            text: 'You can add more reasons later'
+                        },
+                        errorMessage: validationResult.getErrorForField('reason') if validationResult,
+                        items: [
+                            { value: 'illness', text: 'Illness and health issues' },
+                            { value: 'other', text: 'I’m appealing for another reason' }
+                        ]
+                    })
+                }}
+
+                {{ 
+                    govukButton({
+                        text: 'Continue',
+                        attributes: {
+                            id: 'submit'
+                        }
+                    }) 
+                }}
+            </form>
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LFA-1900

### Change description

Adds the govuk-spec Error Banner to the Choose Reason page. Thanks to @richardetherington for spotting.

<img width="1420" alt="Screenshot 2020-07-29 at 10 01 53" src="https://user-images.githubusercontent.com/43062389/88780187-89701880-d182-11ea-8571-d71ce21395d2.png">

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
