### PR TITLE
bugfix: illness start date session reading bug

### DIFF
--- a/src/controllers/IllnessStartDateController.ts
+++ b/src/controllers/IllnessStartDateController.ts
@@ -41,10 +41,14 @@ export class IllnessStartDateController extends BaseController<FormBody> {
         if (!illness) {
             return {};
         }
-        const startDate: Date = new Date(illness.illnessStart);
-        const day: string = startDate.getDate().toString();
-        const month: string = (startDate.getMonth() + 1).toString();
-        const year: string = startDate.getFullYear().toString();
+
+        console.log(illness.illnessStart);
+
+        const dateIngredients = illness.illnessStart.split('-', 3);
+
+        const year: string = dateIngredients[0];
+        const month: string = dateIngredients[1];
+        const day: string = dateIngredients[2];
 
         return {day, month, year};
     }

--- a/src/controllers/IllnessStartDateController.ts
+++ b/src/controllers/IllnessStartDateController.ts
@@ -42,11 +42,7 @@ export class IllnessStartDateController extends BaseController<FormBody> {
             return {};
         }
 
-        const dateIngredients = illness.illnessStart.split('-', 3);
-
-        const year: string = dateIngredients[0];
-        const month: string = dateIngredients[1];
-        const day: string = dateIngredients[2];
+        const [year, month, day]= illness.illnessStart.split('-', 3);
 
         return {day, month, year};
     }

--- a/src/controllers/IllnessStartDateController.ts
+++ b/src/controllers/IllnessStartDateController.ts
@@ -42,8 +42,6 @@ export class IllnessStartDateController extends BaseController<FormBody> {
             return {};
         }
 
-        console.log(illness.illnessStart);
-
         const dateIngredients = illness.illnessStart.split('-', 3);
 
         const year: string = dateIngredients[0];

--- a/test/controllers/IllnessStartDateController.test.ts
+++ b/test/controllers/IllnessStartDateController.test.ts
@@ -36,9 +36,7 @@ describe('IllnessStartDateController', () => {
             companyNumber: 'NI000000',
             penaltyReference: 'A00000001'
         },
-        reasons: {
-            illness: {}
-        }
+        reasons: {}
     } as Appeal;
 
     describe('GET request', () => {
@@ -75,8 +73,8 @@ describe('IllnessStartDateController', () => {
                 .expect(response => {
                     expect(response.status).to.be.equal(OK);
                     expect(response.text).to.contain(pageHeading)
-                        .and.to.contain('id="start-day" name="day" type="text" value="1"')
-                        .and.to.contain('id="start-month" name="month" type="text" value="1"')
+                        .and.to.contain('id="start-day" name="day" type="text" value="01"')
+                        .and.to.contain('id="start-month" name="month" type="text" value="01"')
                         .and.to.contain('id="start-year" name="year" type="text" value="2020"');
                 });
         });


### PR DESCRIPTION
### JIRA link



### Change description

When the page is reloaded after you enter a date, the field is prepopulated with the session as it should ... except that:
for some months, the value of the day, is decremented by one.I dont think this is a problem about how we save the date to session, I think its to do with how we read it.

most likely linked to how new Date() works.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are commited to keeping commit history clean, consistent and linear. To achive this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
