### PR TITLE
fix: Off-By-One bug in Nunjucks Date filter

### DIFF
--- a/src/modules/nunjucks/DateFilter.ts
+++ b/src/modules/nunjucks/DateFilter.ts
@@ -2,7 +2,7 @@ export function dateFilter(value: string): string {
 
     const dateRegex: RegExp = /(\d{4})-(\d{2})-(\d{2})/;
     if (!dateRegex.test(value)) {
-        throw new Error('Input should be formatted as yyyy-MM-dd');
+        throw new Error(`Input should be formatted as yyyy-MM-dd: ${value}`);
     }
 
     // tslint:disable-next-line: prefer-const
@@ -10,8 +10,8 @@ export function dateFilter(value: string): string {
         return parseInt(i, 10);
     });
 
-    if (month > 11 || month < 0) {
-        throw new Error('Input should be formatted as yyyy-MM-dd');
+    if (month > 12 || month < 1) {
+        throw new Error(`Input contains invalid month: ${value}`);
     }
 
     const months = [

--- a/test/modules/nunjucks/DateFilter.test.ts
+++ b/test/modules/nunjucks/DateFilter.test.ts
@@ -4,10 +4,16 @@ import { dateFilter } from 'app/modules/nunjucks/DateFilter';
 
 describe('Date Filter', () => {
     it('should reformat a correctly-formatted datestring into the format dd Month yyyy', () => {
-        const testInput = '2020-05-01';
-        const result = dateFilter(testInput);
+        const testCases = [
+            { input: '1990-01-21', output: '21 January 1990' },
+            { input: '2005-05-13', output: '13 May 2005' },
+            { input: '2015-12-31', output: '31 December 2015' }
+        ];
 
-        expect(result).to.equal('1 May 2020');
+        testCases.forEach(testCase => {
+            const result = dateFilter(testCase.input);
+            expect(result).to.equal(testCase.output);
+        });
     });
 
     it('should throw an error if a date component is missing', () => {
@@ -17,7 +23,7 @@ describe('Date Filter', () => {
 
     it('should throw an error if a date component is invalid', () => {
         const testInput = '2020-20-01';
-        expect(() => dateFilter(testInput)).to.throw('Input should be formatted as yyyy-MM-dd');
+        expect(() => dateFilter(testInput)).to.throw('Input contains invalid month: 2020-20-01');
     });
 
     it('should throw an error if the input format is invalid', () => {


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/LFA-1440

### Change description

Update to the custom date filter for Nunjucks, which expected a month value between 0-11 instead of 1-12 (due to previous use of Date type instead of string). Added unit test cases to cover these scenarios.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
