### PR TITLE
Use DOCKER_BUILDKIT=0 flag for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ IntelliJ does not have a Nunjuck plugin
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-appeals-frontend:latest` or run the following steps to build image locally:
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-appeals-frontend:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-appeals-frontend:latest .`

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -24,7 +24,7 @@ local_resource(
 
 custom_build(
   ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/lfp-appeals-frontend',
-  command = 'docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
   live_update = [
     sync(
       local_path = './dist',


### PR DESCRIPTION
### JIRA link

None

### Change description

Docker releases >=2.4.0.0 have BuildKit enabled by default - this breaks image builds due to a known issue (https://github.com/moby/buildkit/issues/816) with BuildKit and ONBUILD COPY --from directives which we use in our runtime image.

Prefixing `docker build` commands with `DOCKER_BUILDKIT=0` fixes the issue

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
