### PR TITLE
Add either/or type logic on reasons obj and reinforce type-checking

### DIFF
--- a/src/controllers/EvidenceRemovalController.ts
+++ b/src/controllers/EvidenceRemovalController.ts
@@ -76,7 +76,7 @@ class Processor implements FormActionProcessor {
 
         const attachment: Attachment = findAttachment(appeal, request.body.id);
         await this.fileTransferService.delete(attachment.id);
-        appeal.reasons.other.attachments!.splice(appeal.reasons.other.attachments!.indexOf(attachment), 1);
+        appeal.reasons.other!.attachments!.splice(appeal.reasons.other!.attachments!.indexOf(attachment), 1);
     }
 }
 

--- a/src/controllers/EvidenceUploadController.ts
+++ b/src/controllers/EvidenceUploadController.ts
@@ -63,7 +63,7 @@ const continueButtonValidator: Validator = {
             throw new Error('Appeal is undefined');
         }
 
-        const attachments: Attachment[] | undefined = appeal.reasons.other.attachments;
+        const attachments: Attachment[] | undefined = appeal.reasons.other!.attachments;
 
         if (!attachments || attachments.length === 0) {
             return new ValidationResult([new ValidationError('file',
@@ -80,7 +80,10 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
     }
 
     protected prepareViewModelFromAppeal(appeal: Appeal): Record<string, any> & OtherReason {
-        return { ...appeal.reasons?.other, companyNumber: appeal.penaltyIdentifier?.companyNumber };
+        return {
+            ...appeal.reasons?.other as OtherReason,
+            companyNumber: appeal.penaltyIdentifier?.companyNumber
+        };
     }
 
     private async renderUploadError(appeal: Appeal, text: string): Promise<void> {
@@ -133,8 +136,8 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
 
                     if (!request.file) {
                         return await that.renderUploadError(appeal, noFileSelectedError);
-                    } else if (appeal.reasons.other.attachments &&
-                        appeal.reasons.other.attachments.length >= maxNumberOfFiles) {
+                    } else if (appeal.reasons.other!.attachments &&
+                        appeal.reasons.other!.attachments.length >= maxNumberOfFiles) {
                         return await that.renderUploadError(appeal, tooManyFilesError);
                     }
 
@@ -153,7 +156,7 @@ export class EvidenceUploadController extends SafeNavigationBaseController<Other
                     const downloadBaseURI: string = newUriFactory(request)
                         .createAbsoluteUri(DOWNLOAD_FILE_PAGE_URI);
 
-                    appeal.reasons.other.attachments = [...appeal.reasons.other.attachments || [], {
+                    appeal.reasons.other!.attachments = [...appeal.reasons.other!.attachments || [], {
                         id,
                         name: request.file.originalname,
                         contentType: request.file.mimetype,

--- a/src/controllers/IllPersonController.ts
+++ b/src/controllers/IllPersonController.ts
@@ -8,7 +8,6 @@ import { FeatureToggleMiddleware } from 'app/middleware/FeatureToggleMiddleware'
 import { loggerInstance } from 'app/middleware/Logger';
 import { Appeal } from 'app/models/Appeal';
 import { Illness } from 'app/models/Illness';
-import { OtherReason } from 'app/models/OtherReason.ts';
 import { IllPerson } from 'app/models/fields/IllPerson';
 import { schema } from 'app/models/fields/IllPerson.schema';
 import { Feature } from 'app/utils/Feature';
@@ -79,8 +78,7 @@ export class IllPersonController extends BaseController<FormBody> {
 
         } else {
             appeal.reasons = {
-                illness: value as Illness,
-                other: {} as OtherReason
+                illness: value as Illness
             };
         }
 

--- a/src/controllers/OtherReasonController.ts
+++ b/src/controllers/OtherReasonController.ts
@@ -32,7 +32,7 @@ export class OtherReasonController extends SafeNavigationBaseController<OtherRea
     }
 
     protected prepareViewModelFromAppeal(appeal: Appeal): Record<string, any> & OtherReason {
-        return appeal.reasons?.other;
+        return appeal.reasons?.other as OtherReason;
     }
 
     protected prepareSessionModelPriorSave(appeal: Appeal, value: OtherReason): Appeal {

--- a/src/controllers/processors/InternalEmailFormActionProcessor.ts
+++ b/src/controllers/processors/InternalEmailFormActionProcessor.ts
@@ -29,9 +29,9 @@ function buildEmail(userProfile: IUserProfile, appeal: Appeal): Email {
                 },
                 reasons: {
                     other: {
-                        title: appeal.reasons.other.title,
-                        description: appeal.reasons.other.description,
-                        attachments: appeal.reasons.other.attachments?.map(attachment => {
+                        title: appeal.reasons.other!.title,
+                        description: appeal.reasons.other!.description,
+                        attachments: appeal.reasons.other!.attachments?.map(attachment => {
                             return {
                                 name: attachment.name,
                                 url: `${attachment.url}&a=${appeal.id}`

--- a/src/models/Illness.ts
+++ b/src/models/Illness.ts
@@ -1,4 +1,4 @@
-
+import { Attachment } from 'app/models/Attachment';
 import { IllPerson } from 'app/models/fields/IllPerson';
 import { YesNo } from 'app/models/fields/YesNo';
 
@@ -8,4 +8,5 @@ export interface Illness {
     illnessStart: string;
     continuedIllness: YesNo;
     illnessEnd?: string;
+    attachments?: Attachment[];
 }

--- a/src/models/Reasons.ts
+++ b/src/models/Reasons.ts
@@ -1,8 +1,7 @@
 import { Illness } from 'app/models/Illness';
 import { OtherReason } from 'app/models/OtherReason';
 
-export interface Reasons {
-  illness?: Illness;
-  other: OtherReason;
-}
+interface PenaltyIllnessReason { illness: Illness; other?: never; }
+interface PenaltyOtherReason { illness?: never; other: OtherReason; }
 
+export type Reasons =  PenaltyIllnessReason | PenaltyOtherReason;

--- a/test/controllers/CheckYourAppealController.test.ts
+++ b/test/controllers/CheckYourAppealController.test.ts
@@ -74,8 +74,8 @@ describe('CheckYourAppealController', () => {
                         .to.contain(appeal.penaltyIdentifier.penaltyReference).and
                         .to.contain('test').and
                         .to.contain(subHeading).and
-                        .to.contain(appeal.reasons.other.title).and
-                        .to.contain(appeal.reasons.other.description).and
+                        .to.contain(appeal.reasons.other!.title).and
+                        .to.contain(appeal.reasons.other!.description).and
                         .to.contain(`href="/appeal-a-penalty/download/data/1/download?c=${appeal.penaltyIdentifier.companyNumber}"`)
                         .nested.contain('some-file.jpeg').and
                         .to.contain(`href="/appeal-a-penalty/download/data/2/download?c=${appeal.penaltyIdentifier.companyNumber}"`)

--- a/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
+++ b/test/controllers/processors/InternalEmailFormSubmissionProcessor.test.ts
@@ -11,7 +11,9 @@ import { Request } from 'express';
 import { InternalEmailFormActionProcessor } from 'app/controllers/processors/InternalEmailFormActionProcessor';
 import { Appeal } from 'app/models/Appeal';
 import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
+import { OtherReason } from 'app/models/OtherReason';
 import { PenaltyIdentifier } from 'app/models/PenaltyIdentifier';
+import { Reasons } from 'app/models/Reasons';
 import { EmailService } from 'app/modules/email-publisher/EmailService';
 
 import { createSubstituteOf } from 'test/SubstituteFactory';
@@ -137,8 +139,8 @@ describe('InternalEmailFormSubmissionProcessor', () => {
                                 url: 'http://localhost/appeal-a-penalty/download/prompt/123?c=12345678'
                             }
                         ]
-                    }
-                }
+                    } as OtherReason
+                } as Reasons
             }));
 
             emailService.received().send({


### PR DESCRIPTION
### JIRA link
Part of [BI-8248](https://companieshouse.atlassian.net/browse/BI-8248) 


### Change description
Add either/or type logic on reasons and reinforce type-checking to Generalise Appeals Reason Object


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
