### PR TITLE
Feature/bi 8245 add navigation choice between other and illness reason

### DIFF
--- a/src/controllers/ChooseAppealReasonController.ts
+++ b/src/controllers/ChooseAppealReasonController.ts
@@ -2,7 +2,7 @@ import { SessionMiddleware } from 'ch-node-session-handler';
 import { Request } from 'express';
 import { controller } from 'inversify-express-utils';
 
-import { BaseController } from 'app/controllers/BaseController';
+import { SafeNavigationBaseController } from 'app/controllers/SafeNavigationBaseController';
 import { FormValidator } from 'app/controllers/validators/FormValidator';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { CompanyAuthMiddleware } from 'app/middleware/CompanyAuthMiddleware';
@@ -10,7 +10,12 @@ import { FeatureToggleMiddleware } from 'app/middleware/FeatureToggleMiddleware'
 import { schema } from 'app/models/fields/Reason.schema';
 import { ReasonType } from 'app/models/fields/ReasonType';
 import { Feature } from 'app/utils/Feature';
-import { CHOOSE_REASON_PAGE_URI, ILL_PERSON_PAGE_URI, OTHER_REASON_DISCLAIMER_PAGE_URI, REVIEW_PENALTY_PAGE_URI } from 'app/utils/Paths';
+import {
+    CHOOSE_REASON_PAGE_URI,
+    ILL_PERSON_PAGE_URI,
+    OTHER_REASON_DISCLAIMER_PAGE_URI,
+    REVIEW_PENALTY_PAGE_URI
+} from 'app/utils/Paths';
 import { Navigation } from 'app/utils/navigation/navigation';
 
 const template = 'choose-appeal-reason';
@@ -40,7 +45,7 @@ interface FormBody {
 
 @controller(CHOOSE_REASON_PAGE_URI, FeatureToggleMiddleware(Feature.ILLNESS_REASON), SessionMiddleware, AuthMiddleware,
 CompanyAuthMiddleware)
-export class ChooseAppealReasonController extends BaseController<FormBody>{
+export class ChooseAppealReasonController extends SafeNavigationBaseController<FormBody>{
 
     constructor() {
         super(template, navigation, new FormValidator(schema));

--- a/src/controllers/IllnessFurtherInformationController.ts
+++ b/src/controllers/IllnessFurtherInformationController.ts
@@ -1,7 +1,7 @@
 import { SessionMiddleware } from 'ch-node-session-handler';
 import { controller } from 'inversify-express-utils';
 
-import { BaseController } from 'app/controllers/BaseController';
+import { SafeNavigationBaseController } from 'app/controllers/SafeNavigationBaseController';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { FeatureToggleMiddleware } from 'app/middleware/FeatureToggleMiddleware';
 import { loggerInstance } from 'app/middleware/Logger';
@@ -13,9 +13,7 @@ import {
     FURTHER_INFORMATION_PAGE_URI,
     ILLNESS_START_DATE_PAGE_URI
 } from 'app/utils/Paths';
-import { addNavigationPermission } from 'app/utils/appeal/extra.data';
 import { Navigation } from 'app/utils/navigation/navigation';
-
 
 const template = 'illness/illness-information';
 
@@ -25,12 +23,12 @@ const navigation: Navigation = {
     },
     next(): string {
         return EVIDENCE_QUESTION_URI;
-    },
+    }
 };
 
 @controller(FURTHER_INFORMATION_PAGE_URI, FeatureToggleMiddleware(Feature.ILLNESS_REASON),
     SessionMiddleware, AuthMiddleware)
-export class IllnessFurtherInformationController extends BaseController<Illness> {
+export class IllnessFurtherInformationController extends SafeNavigationBaseController<Illness> {
     constructor() {
         super(
             template,
@@ -39,7 +37,6 @@ export class IllnessFurtherInformationController extends BaseController<Illness>
     }
 
     protected prepareSessionModelPriorSave(appeal: Appeal, value: any): Appeal {
-        addNavigationPermission(this.httpContext.request.session, EVIDENCE_QUESTION_URI);
 
         loggerInstance().debug(`
             prepareSessionModelPriorSave: ${value?.description} -

--- a/src/controllers/IllnessStartDateController.ts
+++ b/src/controllers/IllnessStartDateController.ts
@@ -2,7 +2,7 @@ import { SessionMiddleware } from 'ch-node-session-handler';
 import { controller } from 'inversify-express-utils';
 import moment from 'moment';
 
-import { BaseController } from 'app/controllers/BaseController';
+import { SafeNavigationBaseController } from 'app/controllers/SafeNavigationBaseController';
 import { DateValidator } from 'app/controllers/validators/DateValidator';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { FeatureToggleMiddleware } from 'app/middleware/FeatureToggleMiddleware';
@@ -31,7 +31,7 @@ interface FormBody {
 
 @controller(ILLNESS_START_DATE_PAGE_URI, FeatureToggleMiddleware(Feature.ILLNESS_REASON), SessionMiddleware,
     AuthMiddleware)
-export class IllnessStartDateController extends BaseController<FormBody> {
+export class IllnessStartDateController extends SafeNavigationBaseController<FormBody> {
 
     constructor() {
         super(template, navigation, new DateValidator());

--- a/src/controllers/OtherReasonController.ts
+++ b/src/controllers/OtherReasonController.ts
@@ -10,9 +10,11 @@ import { Appeal } from 'app/models/Appeal';
 import { OtherReason } from 'app/models/OtherReason';
 import { schema as formSchema } from 'app/models/OtherReason.schema';
 import {
-    EVIDENCE_QUESTION_URI, OTHER_REASON_DISCLAIMER_PAGE_URI,
+    EVIDENCE_QUESTION_URI,
+    OTHER_REASON_DISCLAIMER_PAGE_URI,
     OTHER_REASON_PAGE_URI
 } from 'app/utils/Paths';
+import { getAttachmentsFromReasons } from 'app/utils/appeal/extra.data';
 
 const template = 'other-reason';
 
@@ -36,7 +38,7 @@ export class OtherReasonController extends SafeNavigationBaseController<OtherRea
     }
 
     protected prepareSessionModelPriorSave(appeal: Appeal, value: OtherReason): Appeal {
-        // TBD: Remove Illness object when creating OtherReason if not Multiple reasons
+        const attachments = getAttachmentsFromReasons(appeal.reasons) || [];
         if (appeal.reasons?.other != null) {
             appeal.reasons.other.title = value.title;
             appeal.reasons.other.description = value.description;
@@ -44,6 +46,7 @@ export class OtherReasonController extends SafeNavigationBaseController<OtherRea
             appeal.reasons = {
                 other: value
             };
+            appeal.reasons.other.attachments = [ ...attachments ];
         }
 
         loggerInstance()

--- a/src/controllers/ReviewPenaltyController.ts
+++ b/src/controllers/ReviewPenaltyController.ts
@@ -1,5 +1,6 @@
 import { SessionMiddleware } from 'ch-node-session-handler';
 import { Penalty } from 'ch-sdk-node/dist/services/lfp';
+import { Request } from 'express';
 import { controller } from 'inversify-express-utils';
 import { SafeNavigationBaseController } from './SafeNavigationBaseController';
 
@@ -8,19 +9,23 @@ import { CheckForDuplicateMiddleware } from 'app/middleware/CheckForDuplicateMid
 import { CompanyAuthMiddleware } from 'app/middleware/CompanyAuthMiddleware';
 import { Appeal } from 'app/models/Appeal';
 import {
+    CHOOSE_REASON_PAGE_URI,
     OTHER_REASON_DISCLAIMER_PAGE_URI,
     REVIEW_PENALTY_PAGE_URI,
     SELECT_THE_PENALTY_PAGE_URI
 } from 'app/utils/Paths';
+import { Navigation } from 'app/utils/navigation/navigation';
 
 const template = 'review-penalty';
 
-const navigation = {
+const navigation: Navigation = {
     previous(): string {
         return `${SELECT_THE_PENALTY_PAGE_URI}?back=true`;
     },
-    next(): string {
-        return OTHER_REASON_DISCLAIMER_PAGE_URI;
+    next(request: Request): string {
+        return (request.app.locals.featureFlags.illnessReasonEnabled)
+            ? CHOOSE_REASON_PAGE_URI
+            : OTHER_REASON_DISCLAIMER_PAGE_URI;
     }
 };
 

--- a/src/utils/ExpressConfigFunctionFactory.ts
+++ b/src/utils/ExpressConfigFunctionFactory.ts
@@ -60,6 +60,7 @@ export const createExpressConfigFunction = (directory: string) => (app: express.
     };
 
     app.locals.featureFlags = {
-        companyAuthVerificationEnabled: Number(getEnvOrDefault('COMPANY_AUTH_VERIFICATION_FEATURE_ENABLED', '0')) === 1
+        companyAuthVerificationEnabled: Number(getEnvOrDefault('COMPANY_AUTH_VERIFICATION_FEATURE_ENABLED', '0')) === 1,
+        illnessReasonEnabled: Number(getEnvOrDefault('ILLNESS_REASON_FEATURE_ENABLED', '0')) === 1
     };
 };

--- a/src/utils/appeal/extra.data.ts
+++ b/src/utils/appeal/extra.data.ts
@@ -1,6 +1,3 @@
-import { Session } from 'ch-node-session-handler';
-
-import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { Attachment } from 'app/models/Attachment';
 import { Illness } from 'app/models/Illness';
 import { OtherReason } from 'app/models/OtherReason';
@@ -43,15 +40,4 @@ export const addAttachmentToReason = (reasons: Reasons, attachment: Attachment):
     const reason = getReasonFromReasons(reasons);
 
     reason!.attachments = [...reason!.attachments || [], attachment];
-};
-
-export const addNavigationPermission = (session: Session | undefined, uriPage: string): void => {
-    const extraData: ApplicationData | undefined = session!.getExtraData(APPLICATION_DATA_KEY);
-
-    if (extraData?.navigation){
-        const permissions = extraData.navigation.permissions || [];
-        extraData.navigation = {
-            permissions: [...permissions, uriPage]
-        };
-    }
 };

--- a/src/views/choose-appeal-reason.njk
+++ b/src/views/choose-appeal-reason.njk
@@ -41,9 +41,6 @@
                 classes: 'govuk-fieldset__legend--xl'
               }
             },
-            hint: {
-              text: 'You can add more reasons later'
-            },
             errorMessage: validationResult.getErrorForField('reason') if validationResult,
             items: [
               { value: 'illness', text: 'Illness and health issues' },

--- a/test/utils/appeal/extra.data.test.ts
+++ b/test/utils/appeal/extra.data.test.ts
@@ -1,16 +1,12 @@
 import { expect } from 'chai';
-import { createSession } from '../session/SessionFactory';
 
 import { Appeal } from 'app/models/Appeal';
-import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { Attachment } from 'app/models/Attachment';
 import { Illness } from 'app/models/Illness';
-import { Navigation } from 'app/models/Navigation';
 import { OtherReason } from 'app/models/OtherReason';
 import { Reasons } from 'app/models/Reasons';
 import {
     addAttachmentToReason,
-    addNavigationPermission,
     findAttachmentByIdFromReasons,
     getAttachmentsFromReasons,
     getReasonFromReasons,
@@ -103,33 +99,5 @@ describe('Appeal Extra Data', () => {
         addAttachmentToReason( emptyAttachments.reasons, secondAttachment);
         expect(emptyAttachments.reasons.other?.attachments).to.be.deep.equal([secondAttachment]);
         expect(emptyAttachments.reasons.other?.attachments?.length).to.be.equal(1);
-    });
-    it('should add new permission to the already existing Navigation permission object', () => {
-        const session = createSession('secret');
-        const navigationPermission = 'some/next/page';
-        const mockExtraData = {
-            appeal: {} as Appeal,
-            navigation: { permissions: [] } as Navigation
-        } as ApplicationData;
-
-        session.setExtraData(APPLICATION_DATA_KEY, mockExtraData);
-
-        addNavigationPermission(session, navigationPermission);
-
-        const extraData: ApplicationData | undefined = session?.getExtraData(APPLICATION_DATA_KEY);
-        const permissionFromExtraData = extraData?.navigation.permissions;
-
-        expect(permissionFromExtraData).to.be.deep.equal([navigationPermission]);
-        expect(permissionFromExtraData?.length).to.be.equal(1);
-    });
-    it('should do nothing when extra data is undefined', () => {
-        const session = createSession('secret');
-        const navigationPermission = 'some/next/page';
-
-        const extraData: ApplicationData | undefined = session?.getExtraData(APPLICATION_DATA_KEY);
-        const permissionFromExtraData = extraData?.navigation.permissions;
-
-        addNavigationPermission(session, navigationPermission);
-        expect(permissionFromExtraData).to.be.equal(undefined);
     });
 });


### PR DESCRIPTION
### JIRA link
Resolves [BI-8245](https://companieshouse.atlassian.net/browse/BI-8245)


### Change description
- Add navigation choice between Other and Illness reason
- Keep attachments object when changing reasons and add safe navigation
- Add safe navigation to the other illness journey pages
- Remove hint from choose-appeal-reason page
- Remove temporary permission logic for Illness further information page


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
