### PR TITLE
Feature/BI-8955 add matomo events continued illness

### DIFF
--- a/src/views/illness/continued-illness.njk
+++ b/src/views/illness/continued-illness.njk
@@ -27,10 +27,7 @@
         {{
           govukErrorSummary ({
             titleText: 'There is a problem with the details you gave us',
-            errorList: validationResult.errors,
-            attributes: {
-                  'data-event-id': '{ errorMessage } '
-                }
+            errorList: validationResult.errors
           }) if validationResult and validationResult.errors.length > 0
         }}
 

--- a/src/views/illness/continued-illness.njk
+++ b/src/views/illness/continued-illness.njk
@@ -27,7 +27,10 @@
         {{
           govukErrorSummary ({
             titleText: 'There is a problem with the details you gave us',
-            errorList: validationResult.errors
+            errorList: validationResult.errors,
+            attributes: {
+                  'data-event-id': '{ errorMessage } '
+                }
           }) if validationResult and validationResult.errors.length > 0
         }}
 
@@ -58,11 +61,17 @@
             items: [
               {
                 value: 'yes',
-                text: 'Yes'
+                text: 'Yes',
+                attributes: {
+                  'data-event-id': 'yes-selected'
+                }
               },
               {
                 value: 'no',
-                text: 'No'
+                text: 'No',
+                attributes: {
+                  'data-event-id': 'no-selected'
+                }
               }
             ]
           })


### PR DESCRIPTION
### JIRA link
Resolves [BI-8955](https://companieshouse.atlassian.net/browse/BI-8955)


### Change description
Adding Matomo events on the radio buttons to record the user's selection for options 'yes' or 'no' on 'is this person still ill'(continued illness) page.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
