### PR TITLE
Adding Matomo event when clicking continue button on illness end date page

### DIFF
--- a/src/views/illness/illness-end-date.njk
+++ b/src/views/illness/illness-end-date.njk
@@ -115,7 +115,8 @@
           govukButton ({
             text: 'Continue',
             attributes: {
-              id: 'submit'
+              id: 'submit',
+              'data-event-id': 'clicked continue'
             }
           })
         }}


### PR DESCRIPTION
### JIRA link
Resolves [BI-8950](https://companieshouse.atlassian.net/browse/BI-8950)



### Change description
Adding Matomo event to be tracked when clicking continue button on when did illness end page


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
