### PR TITLE
Add illness end date logic

### DIFF
--- a/test/controllers/IllnessEndDateController.test.ts
+++ b/test/controllers/IllnessEndDateController.test.ts
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import {
     INTERNAL_SERVER_ERROR,
     MOVED_TEMPORARILY,
-    OK
+    OK,
+    UNPROCESSABLE_ENTITY
 } from 'http-status-codes';
 import request from 'supertest';
 
@@ -17,6 +18,12 @@ import {
 import { createApp } from 'test/ApplicationFactory';
 
 const pageHeading: string = 'When did the illness end?';
+const errorSummaryHeading: string = 'There is a problem';
+const invalidStartDayErrorMessage: string = 'You must enter a day';
+const invalidStartMonthErrorMessage: string = 'You must enter a month';
+const invalidStartYearErrorMessage: string = 'You must enter a year';
+const invalidDateErrorMessage: string = 'Enter a real date';
+const invalidDateFutureErrorMessage: string = 'Start date must be today or in the past';
 const errorLoadingPage = 'Sorry, there is a problem with the service';
 
 describe('IllnessEndDateController', () => {
@@ -65,7 +72,7 @@ describe('IllnessEndDateController', () => {
 
     describe('POST request', () => {
 
-        it('should redirect to Continued Illness page when posting a valid date', async () => {
+        it('should redirect to Futher Information page when posting a valid date', async () => {
             process.env.ILLNESS_REASON_FEATURE_ENABLED = '1';
 
             const app = createApp({appeal});
@@ -76,6 +83,89 @@ describe('IllnessEndDateController', () => {
                     expect(response.header.location).to.include(FURTHER_INFORMATION_PAGE_URI);
                 });
         });
+
+        it('should return 422 response with rendered error messages when empty start date was submitted', async () => {
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({})
+                .expect(response => {
+                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                    expect(response.text).to.include(pageHeading)
+                        .and.to.include(errorSummaryHeading)
+                        .and.to.include(invalidStartDayErrorMessage)
+                        .and.to.include(invalidStartMonthErrorMessage)
+                        .and.to.include(invalidStartYearErrorMessage)
+                        .and.to.not.include(invalidDateErrorMessage)
+                        .and.to.not.include(invalidDateFutureErrorMessage);
+                });
+        });
+        it('should return 422 response with rendered error messages when partial start date was submitted',
+        async () => {
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({month: '01', year: '2020'})
+                .expect(response => {
+                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                    expect(response.text).to.include(pageHeading)
+                        .and.to.include(errorSummaryHeading)
+                        .and.to.include(invalidStartDayErrorMessage)
+                        .and.to.not.include(invalidDateErrorMessage)
+                        .and.to.not.include(invalidDateFutureErrorMessage);
+                });
+        });
+
+    it('should return 422 response with rendered error message invalid start date (all zeros) was submitted',
+        async () => {
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({day: '00', month: '00', year: '0000'})
+                .expect(response => {
+                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                    expect(response.text).to.include(pageHeading)
+                        .and.to.include(errorSummaryHeading)
+                        .and.to.include(invalidDateErrorMessage);
+                });
+        });
+
+    it('should return 422 response with rendered error message invalid start date (non-existing) was submitted',
+        async () => {
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({day: '32', month: '13', year: '2020'})
+                .expect(response => {
+                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                    expect(response.text).to.include(pageHeading)
+                        .and.to.include(errorSummaryHeading)
+                        .and.to.include(invalidDateErrorMessage);
+                });
+        });
+
+    it('should return 422 response with rendered error message invalid start date (in future) was submitted',
+        async () => {
+            const futureYear = (new Date().getFullYear() + 1).toString();
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({day: '01', month: '01', year: futureYear})
+                .expect(response => {
+                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                    expect(response.text).to.include(pageHeading)
+                        .and.to.include(errorSummaryHeading)
+                        .and.to.include(invalidDateFutureErrorMessage);
+                });
+        });
+
+    it('should redirect to entry page when illness reason feature is disabled', async () => {
+
+        process.env.ILLNESS_REASON_FEATURE_ENABLED = '0';
+
+        const app = createApp({appeal});
+        await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+            .send({})
+            .expect(response => {
+                expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                expect(response.header.location).to.include(ENTRY_PAGE_URI);
+            });
+    });
 
     });
 });

--- a/test/controllers/IllnessEndDateController.test.ts
+++ b/test/controllers/IllnessEndDateController.test.ts
@@ -5,10 +5,12 @@ import {
     OK,
     UNPROCESSABLE_ENTITY
 } from 'http-status-codes';
+import moment from 'moment';
 import request from 'supertest';
 
 import 'app/controllers/EvidenceDownloadController';
 import { Appeal } from 'app/models/Appeal';
+import { IllPerson } from 'app/models/fields/IllPerson';
 import {
     ENTRY_PAGE_URI,
     FURTHER_INFORMATION_PAGE_URI,
@@ -25,8 +27,19 @@ const invalidStartYearErrorMessage: string = 'You must enter a year';
 const invalidDateErrorMessage: string = 'Enter a real date';
 const invalidDateFutureErrorMessage: string = 'Start date must be today or in the past';
 const errorLoadingPage = 'Sorry, there is a problem with the service';
+let initialIllnessReasonFeatureFlag: string | undefined;
 
 describe('IllnessEndDateController', () => {
+
+    before(done => {
+        initialIllnessReasonFeatureFlag = process.env.ILLNESS_REASON_FEATURE_ENABLED;
+        done();
+    });
+
+    after(done => {
+        process.env.ILLNESS_REASON_FEATURE_ENABLED = initialIllnessReasonFeatureFlag;
+        done();
+    });
 
     const appeal = {
         penaltyIdentifier: {},
@@ -39,6 +52,26 @@ describe('IllnessEndDateController', () => {
 
         it('should return 200 when trying to access the page', async () => {
             process.env.ILLNESS_REASON_FEATURE_ENABLED = '1';
+
+            const app = createApp({appeal, navigation});
+            await request(app).get(ILLNESS_END_DATE_PAGE_URI).expect(response => {
+                expect(response.status).to.be.equal(OK);
+                expect(response.text).to.contain(pageHeading);
+            });
+        });
+
+        it('should return 200 when trying to access the page with illness end date populated', async () => {
+            process.env.ILLNESS_REASON_FEATURE_ENABLED = '1';
+
+            appeal.reasons = {
+                illness: {
+                    illPerson: IllPerson.director,
+                    illnessStart: moment('2019-12-31').format('YYYY-MM-DD'),
+                    continuedIllness: false,
+                    illnessImpactFurtherInformation: 'test',
+                    illnessEnd: moment('2020-01-01').format('YYYY-MM-DD')
+                }
+            };
 
             const app = createApp({appeal, navigation});
             await request(app).get(ILLNESS_END_DATE_PAGE_URI).expect(response => {
@@ -72,8 +105,12 @@ describe('IllnessEndDateController', () => {
 
     describe('POST request', () => {
 
-        it('should redirect to Futher Information page when posting a valid date', async () => {
+        beforeEach(done => {
             process.env.ILLNESS_REASON_FEATURE_ENABLED = '1';
+            done();
+        });
+
+        it('should redirect to Futher Information page when posting a valid date', async () => {
 
             const app = createApp({appeal});
             await request(app).post(ILLNESS_END_DATE_PAGE_URI)
@@ -84,7 +121,26 @@ describe('IllnessEndDateController', () => {
                 });
         });
 
-        it('should return 422 response with rendered error messages when empty start date was submitted', async () => {
+        it('should redirect to Futher Information page when posting a valid date', async () => {
+            appeal.reasons = {
+                illness: {
+                    illPerson: IllPerson.director,
+                    illnessStart: moment('2019-12-31').format('YYYY-MM-DD'),
+                    continuedIllness: false,
+                    illnessImpactFurtherInformation: 'test'
+                }
+            };
+
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({day: '01', month: '01', year: '2020'})
+                .expect(response => {
+                    expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                    expect(response.header.location).to.include(FURTHER_INFORMATION_PAGE_URI);
+                });
+        });
+
+        it('should return 422 response with rendered error messages when empty end date was submitted', async () => {
             const app = createApp({appeal});
             await request(app).post(ILLNESS_END_DATE_PAGE_URI)
                 .send({})
@@ -99,8 +155,8 @@ describe('IllnessEndDateController', () => {
                         .and.to.not.include(invalidDateFutureErrorMessage);
                 });
         });
-        it('should return 422 response with rendered error messages when partial start date was submitted',
-        async () => {
+
+        it('should return 422 response with rendered error messages when partial end date was submitted', async () => {
             const app = createApp({appeal});
             await request(app).post(ILLNESS_END_DATE_PAGE_URI)
                 .send({month: '01', year: '2020'})
@@ -114,58 +170,57 @@ describe('IllnessEndDateController', () => {
                 });
         });
 
-    it('should return 422 response with rendered error message invalid start date (all zeros) was submitted',
-        async () => {
-            const app = createApp({appeal});
-            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
-                .send({day: '00', month: '00', year: '0000'})
-                .expect(response => {
-                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
-                    expect(response.text).to.include(pageHeading)
-                        .and.to.include(errorSummaryHeading)
-                        .and.to.include(invalidDateErrorMessage);
-                });
-        });
-
-    it('should return 422 response with rendered error message invalid start date (non-existing) was submitted',
-        async () => {
-            const app = createApp({appeal});
-            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
-                .send({day: '32', month: '13', year: '2020'})
-                .expect(response => {
-                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
-                    expect(response.text).to.include(pageHeading)
-                        .and.to.include(errorSummaryHeading)
-                        .and.to.include(invalidDateErrorMessage);
-                });
-        });
-
-    it('should return 422 response with rendered error message invalid start date (in future) was submitted',
-        async () => {
-            const futureYear = (new Date().getFullYear() + 1).toString();
-            const app = createApp({appeal});
-            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
-                .send({day: '01', month: '01', year: futureYear})
-                .expect(response => {
-                    expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
-                    expect(response.text).to.include(pageHeading)
-                        .and.to.include(errorSummaryHeading)
-                        .and.to.include(invalidDateFutureErrorMessage);
-                });
-        });
-
-    it('should redirect to entry page when illness reason feature is disabled', async () => {
-
-        process.env.ILLNESS_REASON_FEATURE_ENABLED = '0';
-
-        const app = createApp({appeal});
-        await request(app).post(ILLNESS_END_DATE_PAGE_URI)
-            .send({})
-            .expect(response => {
-                expect(response.status).to.be.equal(MOVED_TEMPORARILY);
-                expect(response.header.location).to.include(ENTRY_PAGE_URI);
+        it('should return 422 response with rendered error message invalid end date (all zeros) was submitted',
+            async () => {
+                const app = createApp({appeal});
+                await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                    .send({day: '00', month: '00', year: '0000'})
+                    .expect(response => {
+                        expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                        expect(response.text).to.include(pageHeading)
+                            .and.to.include(errorSummaryHeading)
+                            .and.to.include(invalidDateErrorMessage);
+                    });
             });
-    });
 
+        it('should return 422 response with rendered error message invalid start date (non-existing) was submitted',
+            async () => {
+                const app = createApp({appeal});
+                await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                    .send({day: '32', month: '13', year: '2020'})
+                    .expect(response => {
+                        expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                        expect(response.text).to.include(pageHeading)
+                            .and.to.include(errorSummaryHeading)
+                            .and.to.include(invalidDateErrorMessage);
+                    });
+            });
+
+        it('should return 422 response with rendered error message invalid start date (in future) was submitted',
+            async () => {
+                const futureYear = (new Date().getFullYear() + 1).toString();
+                const app = createApp({appeal});
+                await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                    .send({day: '01', month: '01', year: futureYear})
+                    .expect(response => {
+                        expect(response.status).to.be.equal(UNPROCESSABLE_ENTITY);
+                        expect(response.text).to.include(pageHeading)
+                            .and.to.include(errorSummaryHeading)
+                            .and.to.include(invalidDateFutureErrorMessage);
+                    });
+            });
+
+        it('should redirect to entry page when illness reason feature is disabled', async () => {
+
+            process.env.ILLNESS_REASON_FEATURE_ENABLED = '0';
+
+            const app = createApp({appeal});
+            await request(app).post(ILLNESS_END_DATE_PAGE_URI)
+                .send({})
+                .expect(response => {
+                    expect(response.status).to.be.equal(MOVED_TEMPORARILY);
+                    expect(response.header.location).to.include(ENTRY_PAGE_URI);
+                });
+        });
     });
 });

--- a/test/utils/appeal/extra.data.test.ts
+++ b/test/utils/appeal/extra.data.test.ts
@@ -64,12 +64,12 @@ describe('Appeal Extra Data', () => {
     } as Attachment;
     const navigation: Navigation = { permissions: [] };
 
-    it('shoult return other reason object from Reasons', () => {
+    it('should return other reason object from Reasons', () => {
         const reason = getReasonFromReasons(appealOtherReason.reasons);
         expect(reason).to.be.equal(appealOtherReason.reasons.other);
     });
 
-    it('shoult return illness reason object from Reasons', () => {
+    it('should return illness reason object from Reasons', () => {
         const reason = getReasonFromReasons(appealIllnessReason.reasons);
         expect(reason).to.be.equal(appealIllnessReason.reasons.illness);
     });


### PR DESCRIPTION
[BI-8948](https://companieshouse.atlassian.net/browse/BI-8948)


Add logic to store the illness end date in the session.
Update function prepareViewModelFromAppeal to check if illnessEnd value is set and if so split it out in to day, month and year and return
Update function prepareSessionModelPriorSave to set the illnessEnd value onto the session value
Add unit tests for new functionality


### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
