### PR TITLE
Add validation to illness end date

### DIFF
--- a/src/controllers/IllnessEndDateController.ts
+++ b/src/controllers/IllnessEndDateController.ts
@@ -1,9 +1,9 @@
 import { SessionMiddleware } from 'ch-node-session-handler';
 import { controller } from 'inversify-express-utils';
 import moment from 'moment';
+import { IllnessEndDateValidator } from './validators/IllnessEndDateValidator';
 
 import { SafeNavigationBaseController } from 'app/controllers/SafeNavigationBaseController';
-import { DateValidator } from 'app/controllers/validators/DateValidator';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
 import { FeatureToggleMiddleware } from 'app/middleware/FeatureToggleMiddleware';
 import { loggerInstance, loggingMessage } from 'app/middleware/Logger';
@@ -34,7 +34,7 @@ interface FormBody {
 export class IllnessEndDateController extends SafeNavigationBaseController<FormBody> {
 
     constructor() {
-        super(template, navigation, new DateValidator());
+        super(template, navigation, new IllnessEndDateValidator());
     }
 
     protected prepareViewModelFromAppeal(appeal: Appeal): any {

--- a/src/controllers/validators/IllnessEndDateValidator.ts
+++ b/src/controllers/validators/IllnessEndDateValidator.ts
@@ -43,7 +43,7 @@ export class IllnessEndDateValidator extends DateValidator {
         const validationResult: ValidationResult = await super.validate(request);
 
 
-        const illness: Illness | undefined = appData.appeal.reasons!.illness;
+        const illness: Illness | undefined = appData.appeal.reasons.illness;
         if (illness != null && illness.illnessStart != null) {
 
             const illnessStartDate = moment(illness.illnessStart).toDate();

--- a/src/controllers/validators/IllnessEndDateValidator.ts
+++ b/src/controllers/validators/IllnessEndDateValidator.ts
@@ -4,10 +4,9 @@ import moment from 'moment';
 
 import { DateValidator } from 'app/controllers/validators/DateValidator';
 import { loggerInstance, loggingMessage } from 'app/middleware/Logger';
-import { Appeal } from 'app/models/Appeal';
 import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
 import { Illness } from 'app/models/Illness';
-import { SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
+import { APPLICATION_DATA_UNDEFINED, SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
 import { ValidationError } from 'app/utils/validation/ValidationError';
 import { ValidationResult } from 'app/utils/validation/ValidationResult';
 
@@ -26,32 +25,34 @@ export class IllnessEndDateValidator extends DateValidator {
         const yearField: string = 'year';
         const dateField: string = 'date';
 
-        request.body.date = moment(`${request.body[yearField]}-${request.body[monthField]}-${request.body[dayField]}`)
-            .toDate();
-
-        const validationResult: ValidationResult = await super.validate(request);
-
         const session: Session | undefined = request.session;
 
         if (!session) {
             throw SESSION_NOT_FOUND_ERROR;
         }
 
-        const appData: ApplicationData = session.getExtraData<ApplicationData>(APPLICATION_DATA_KEY)
-            || { appeal: {} as Appeal, navigation: { permissions: [] } } as ApplicationData;
+        const appData: ApplicationData | undefined = session.getExtraData<ApplicationData>(APPLICATION_DATA_KEY);
 
-        // Validate that end date is not before start date
-        const appeal: Appeal | undefined = appData?.appeal;
-        if (appeal != null) {
-            const illness: Illness | undefined = appeal.reasons?.illness;
-            if (illness != null && illness.illnessStart != null) {
-                const illnessStartDate = moment(illness.illnessStart).toDate();
-                if (request.body.date < illnessStartDate) {
-                    loggerInstance().debug(loggingMessage(appeal, IllnessEndDateValidator.name));
-                    const dateError: ValidationError =
-                        new ValidationError(dateField, this.ILLNESS_END_DATE_BEFORE_ILLNESS_START_DATE);
-                    validationResult.errors.push(dateError);
-                }
+        if (!appData) {
+            throw APPLICATION_DATA_UNDEFINED;
+        }
+
+        request.body.date = moment(`${request.body[yearField]}-${request.body[monthField]}-${request.body[dayField]}`)
+            .toDate();
+
+        const validationResult: ValidationResult = await super.validate(request);
+
+
+        const illness: Illness | undefined = appData.appeal.reasons!.illness;
+        if (illness != null && illness.illnessStart != null) {
+
+            const illnessStartDate = moment(illness.illnessStart).toDate();
+            if (request.body.date < illnessStartDate) {
+                loggerInstance().debug(loggingMessage(appData.appeal, IllnessEndDateValidator.name));
+
+                const dateError: ValidationError =
+                    new ValidationError(dateField, this.ILLNESS_END_DATE_BEFORE_ILLNESS_START_DATE);
+                validationResult.errors.push(dateError);
             }
         }
 

--- a/src/controllers/validators/IllnessEndDateValidator.ts
+++ b/src/controllers/validators/IllnessEndDateValidator.ts
@@ -1,0 +1,60 @@
+import { Session } from 'ch-node-session-handler';
+import { Request } from 'express';
+import moment from 'moment';
+
+import { DateValidator } from 'app/controllers/validators/DateValidator';
+import { loggerInstance, loggingMessage } from 'app/middleware/Logger';
+import { Appeal } from 'app/models/Appeal';
+import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
+import { Illness } from 'app/models/Illness';
+import { SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
+import { ValidationError } from 'app/utils/validation/ValidationError';
+import { ValidationResult } from 'app/utils/validation/ValidationResult';
+
+export class IllnessEndDateValidator extends DateValidator {
+
+    private ILLNESS_END_DATE_BEFORE_ILLNESS_START_DATE: string = 'End date must be after the start date';
+
+    constructor() {
+        super();
+    }
+
+    public async validate(request: Request): Promise<ValidationResult> {
+
+        const dayField: string = 'day';
+        const monthField: string = 'month';
+        const yearField: string = 'year';
+        const dateField: string = 'date';
+
+        request.body.date = moment(`${request.body[yearField]}-${request.body[monthField]}-${request.body[dayField]}`)
+            .toDate();
+
+        const validationResult: ValidationResult = await super.validate(request);
+
+        const session: Session | undefined = request.session;
+
+        if (!session) {
+            throw SESSION_NOT_FOUND_ERROR;
+        }
+
+        const appData: ApplicationData = session.getExtraData<ApplicationData>(APPLICATION_DATA_KEY)
+            || { appeal: {} as Appeal, navigation: { permissions: [] } } as ApplicationData;
+
+        // Validate that end date is not before start date
+        const appeal: Appeal | undefined = appData?.appeal;
+        if (appeal != null) {
+            const illness: Illness | undefined = appeal.reasons?.illness;
+            if (illness != null && illness.illnessStart != null) {
+                const illnessStartDate = moment(illness.illnessStart).toDate();
+                if (request.body.date < illnessStartDate) {
+                    loggerInstance().debug(loggingMessage(appeal, IllnessEndDateValidator.name));
+                    const dateError: ValidationError =
+                        new ValidationError(dateField, this.ILLNESS_END_DATE_BEFORE_ILLNESS_START_DATE);
+                    validationResult.errors.push(dateError);
+                }
+            }
+        }
+
+        return validationResult;
+    }
+}

--- a/src/models/fields/Date.schema.ts
+++ b/src/models/fields/Date.schema.ts
@@ -4,7 +4,7 @@ const invalidDayErrorMessage: string = 'You must enter a day';
 const invalidMonthErrorMessage: string = 'You must enter a month';
 const invalidYearErrorMessage: string = 'You must enter a year';
 const invalidDateErrorMessage: string = 'Enter a real date';
-const startDateInFutureErrorMessage: string = 'Start date must be today or in the past';
+const dateInFutureErrorMessage: string = 'Date must be today or in the past';
 
 const dayMonthRegex: RegExp = /^[0-9]{1,2}$/;
 const yearRegex: RegExp = /^[0-9]{4}$/;
@@ -45,6 +45,6 @@ export const schema = Joi.object({
             'any.required': invalidDateErrorMessage,
             'date.base': invalidDateErrorMessage,
             'date.format': invalidDateErrorMessage,
-            'date.max': startDateInFutureErrorMessage
+            'date.max': dateInFutureErrorMessage
         })
 });

--- a/test/controllers/IllnessEndDateController.test.ts
+++ b/test/controllers/IllnessEndDateController.test.ts
@@ -7,7 +7,6 @@ import {
     OK,
     UNPROCESSABLE_ENTITY
 } from 'http-status-codes';
-import moment from 'moment';
 import request from 'supertest';
 
 import 'app/controllers/EvidenceDownloadController';
@@ -49,6 +48,13 @@ describe('IllnessEndDateController', () => {
         reasons: {}
     } as Appeal;
 
+    const illness = {
+        illPerson: IllPerson.director,
+        illnessStart: '2019-12-31',
+        continuedIllness: false,
+        illnessImpactFurtherInformation: 'test'
+    };
+
     const navigation = { permissions: [ILLNESS_END_DATE_PAGE_URI] };
 
     describe('GET request', () => {
@@ -66,15 +72,8 @@ describe('IllnessEndDateController', () => {
         it('should return 200 when trying to access the page with illness end date populated', async () => {
             process.env.ILLNESS_REASON_FEATURE_ENABLED = '1';
 
-            appeal.reasons = {
-                illness: {
-                    illPerson: IllPerson.director,
-                    illnessStart: moment('2019-12-31').format('YYYY-MM-DD'),
-                    continuedIllness: false,
-                    illnessImpactFurtherInformation: 'test',
-                    illnessEnd: moment('2020-01-01').format('YYYY-MM-DD')
-                }
-            };
+            const localAppeal = { ...appeal };
+            localAppeal.reasons = { illness: { ...illness, illnessEnd: '2020-01-01' } };
 
             const app = createApp({appeal, navigation});
             await request(app).get(ILLNESS_END_DATE_PAGE_URI).expect(response => {
@@ -125,16 +124,10 @@ describe('IllnessEndDateController', () => {
         });
 
         it('should redirect to Futher Information page when posting a valid date', async () => {
-            appeal.reasons = {
-                illness: {
-                    illPerson: IllPerson.director,
-                    illnessStart: moment('2019-12-31').format('YYYY-MM-DD'),
-                    continuedIllness: false,
-                    illnessImpactFurtherInformation: 'test'
-                }
-            };
+            const localAppeal = { ...appeal };
+            localAppeal.reasons = { illness };
 
-            const app = createApp({appeal});
+            const app = createApp({ appeal: localAppeal });
             await request(app).post(ILLNESS_END_DATE_PAGE_URI)
                 .send({day: '01', month: '01', year: '2020'})
                 .expect(response => {
@@ -215,17 +208,10 @@ describe('IllnessEndDateController', () => {
 
         it('should return 422 response with rendered error message invalid end date (before start date) was submitted',
             async () => {
+                const localAppeal = { ...appeal };
+                localAppeal.reasons = { illness: { ...illness, illnessStart: '2021-01-01' } };
 
-                appeal.reasons = {
-                    illness: {
-                        illPerson: IllPerson.director,
-                        illnessStart: moment('2021-01-01').format('YYYY-MM-DD'),
-                        continuedIllness: false,
-                        illnessImpactFurtherInformation: 'test'
-                    }
-                };
-
-                const app = createApp({appeal});
+                const app = createApp({appeal: localAppeal});
                 await request(app).post(ILLNESS_END_DATE_PAGE_URI)
                     .send({day: '31', month: '12', year: '2020'})
                     .expect(response => {

--- a/test/controllers/IllnessStartDateController.test.ts
+++ b/test/controllers/IllnessStartDateController.test.ts
@@ -24,7 +24,7 @@ const invalidStartDayErrorMessage: string = 'You must enter a day';
 const invalidStartMonthErrorMessage: string = 'You must enter a month';
 const invalidStartYearErrorMessage: string = 'You must enter a year';
 const invalidDateErrorMessage: string = 'Enter a real date';
-const invalidDateFutureErrorMessage: string = 'Start date must be today or in the past';
+const invalidDateFutureErrorMessage: string = 'Date must be today or in the past';
 const errorLoadingPage = 'Sorry, there is a problem with the service';
 let initialIllnessReasonFeatureFlag: string | undefined;
 

--- a/test/models/chunks/DateSchema.test.ts
+++ b/test/models/chunks/DateSchema.test.ts
@@ -120,7 +120,7 @@ describe('Date schema', () => {
             date: moment('2030-01-01').toDate()
         });
         assertValidationErrors(validationResult, [
-            new ValidationError(dateField, 'Start date must be today or in the past')
+            new ValidationError(dateField, 'Date must be today or in the past')
         ]);
     });
 

--- a/test/utils/validation/IllnessEndDateValidator.test.ts
+++ b/test/utils/validation/IllnessEndDateValidator.test.ts
@@ -1,0 +1,31 @@
+import { assert, expect } from 'chai';
+import { Request } from 'express';
+
+import { IllnessEndDateValidator } from 'app/controllers/validators/IllnessEndDateValidator';
+import { APPLICATION_DATA_UNDEFINED, SESSION_NOT_FOUND_ERROR } from 'app/utils/CommonErrors';
+
+import { createSession } from 'test/utils/session/SessionFactory';
+
+describe('IllnessEndDateValidator', () => {
+    it('should throw an error if session is undefined', async () => {
+        const illnessEndDateValidator = new IllnessEndDateValidator();
+        try {
+            await illnessEndDateValidator.validate({} as Request);
+            assert.fail('Should have thrown an error');
+        } catch (err) {
+            expect(err.message).to.equal(SESSION_NOT_FOUND_ERROR.message);
+        }
+    });
+
+    it('should throw an error if appData is undefined', async () => {
+        const illnessEndDateValidator = new IllnessEndDateValidator();
+        const session = createSession('secret', false);
+
+        try {
+            await illnessEndDateValidator.validate({ session } as Request);
+            assert.fail('Should have thrown an error');
+        } catch (err) {
+            expect(err.message).to.equal(APPLICATION_DATA_UNDEFINED.message);
+        }
+    });
+});


### PR DESCRIPTION
[BI-8946](https://companieshouse.atlassian.net/browse/BI-8946)

Create new validator class IllnessEndDateValidator. This extends DateValidator and includes functionality to check whether the end date is before the start date.
Update IllnessEndDateController to use new validator class, IllnessEndDateValidator.
Update start date in future error message to date in future error message to make now generic

### Work checklist

- [x] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
