### PR TITLE
Removing 'continue without uploading documents' link 

### DIFF
--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -101,13 +101,7 @@
           })
         }}
       </form>
-
-      <form method="post" action="{{ navigation.actions.continueWithoutUpload }}">
-        <button role="link" type="submit" id="no-evidence-link" class="btn-link" data-event-id="Continue without uploading" >
-          Continue without uploading documents
-        </button>
-      </form>
-
+      
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### JIRA link
Resolves [BI-9126](https://companieshouse.atlassian.net/browse/BI-9126)

### Change description
Removing the 'continue without uploading documents' link on 'upload your evidence page'



### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
