### PR TITLE
Fix issue with hint not displaying on illness end date when errors

### DIFF
--- a/src/controllers/IllnessEndDateController.ts
+++ b/src/controllers/IllnessEndDateController.ts
@@ -12,7 +12,6 @@ import { Illness} from 'app/models/Illness';
 import { Reasons} from 'app/models/Reasons';
 import { Feature } from 'app/utils/Feature';
 import { CONTINUED_ILLNESS_PAGE_URI, FURTHER_INFORMATION_PAGE_URI, ILLNESS_END_DATE_PAGE_URI} from 'app/utils/Paths';
-import { formatDate } from 'app/utils/appeal/extra.data';
 import { Navigation } from 'app/utils/navigation/navigation';
 
 const template: string = 'illness/illness-end-date';
@@ -40,15 +39,15 @@ export class IllnessEndDateController extends SafeNavigationBaseController<FormB
 
     protected prepareViewModelFromAppeal(appeal: Appeal): any {
         const illness: Illness | undefined = appeal.reasons?.illness;
-        const illnessStart = appeal.reasons.illness?.illnessStart || '';
-        const illnessStartedOnDate = `You told us the illness started on ${formatDate(illnessStart)}`;
+        const illnessStart = appeal.reasons.illness?.illnessStart;
+
         if (!illness?.illnessEnd) {
-            return {illnessStartedOnDate};
+            return {illnessStart};
         }
 
         const [year, month, day] = illness.illnessEnd.split('-', 3);
 
-        return {day, month, year, illnessStartedOnDate};
+        return {day, month, year, illnessStart};
     }
 
     protected prepareSessionModelPriorSave(appeal: Appeal, value: FormBody): Appeal {

--- a/src/models/fields/Date.schema.ts
+++ b/src/models/fields/Date.schema.ts
@@ -46,5 +46,8 @@ export const schema = Joi.object({
             'date.base': invalidDateErrorMessage,
             'date.format': invalidDateErrorMessage,
             'date.max': dateInFutureErrorMessage
-        })
+        }),
+    // Optional field to post illness start date on illness end date page
+    illnessStart: Joi.string()
+        .optional()
 });

--- a/src/views/illness/illness-end-date.njk
+++ b/src/views/illness/illness-end-date.njk
@@ -4,6 +4,7 @@
 {% from 'govuk/components/error-summary/macro.njk' import govukErrorSummary %}
 {% from 'govuk/components/button/macro.njk' import govukButton %}
 {% from 'govuk/components/date-input/macro.njk' import govukDateInput %}
+{% from 'govuk/components/input/macro.njk' import govukInput %}
 
 {% block pageTitle %}
    Appeal due to ill health: Tell us when the illness ended
@@ -69,6 +70,14 @@
         {% endif %}
 
         {{
+          govukInput({
+            type: 'hidden',
+            name: 'illnessStart',
+            value: illnessStart
+          })
+        }}
+
+        {{
           govukDateInput ({
             id: 'illness-end',
             fieldset: {
@@ -79,7 +88,7 @@
               }
             },
             hint: {
-              text: illnessStartedOnDate
+              text: 'You told us the illness started on ' + illnessStart | date
             },
             errorMessage: illnessEndErrorMessage,
             items: [


### PR DESCRIPTION
### JIRA link
[BI-9140](https://companieshouse.atlassian.net/browse/BI-9140)


### Change description
Add hidden govukInput field to illness-end-date.njk and update the hint text to be consistant with how its been done for the continued illness page.
Add optional field to the Date.schema.ts file. This has been added as an effect of having the hidden input field to store the hint text.
Update IllnessEndDateController to only send the illness start date rather than a formatted string.

### Work checklist

- [x] Tests added where applicable
- [x] UI changes look good on mobile
- [x] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
