### PR TITLE
Amending help text on 'what are the penalty details page'

### DIFF
--- a/src/views/penalty-details.njk
+++ b/src/views/penalty-details.njk
@@ -51,10 +51,10 @@
         {{
           govukInput({
             label: {
-              text: 'Reference number'
+              text: 'Penalty reference'
             },
             hint: {
-              text: 'This is the reference shown on the penalty notice.'
+              text: 'Enter the full penalty reference. It will be in the format A0000000, PEN1A/00000000 or PEN2A/00000000.'
             },
             errorMessage: validationResult.getErrorForField('userInputPenaltyReference') if validationResult,
             classes: 'govuk-input--penalty-reference',
@@ -66,6 +66,9 @@
         }}
         <div class="govuk-form-group">
           {% set detailsHTML %}
+            <p>
+              Your company number and penalty reference will be on your penalty notice letter.
+            </p>
             <p>
               Some penalty notices will show the company number and reference number at the bottom.
               The penalty reference will be in the format A00000000.


### PR DESCRIPTION


### JIRA link
Resolves [BI-9239)](https://companieshouse.atlassian.net/browse/BI-9239)


### Change description
Amending help text on the 'What are the penalty details?' screen to explain in a clearer way what the user needs to enter as a reference number / penalty reference.


### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
