### PR TITLE
Show sign out block on remove document page

### DIFF
--- a/src/controllers/EvidenceRemovalController.ts
+++ b/src/controllers/EvidenceRemovalController.ts
@@ -19,6 +19,7 @@ import { FileTransferService } from 'app/modules/file-transfer-service/FileTrans
 import { EVIDENCE_REMOVAL_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI, SIGNOUT_PAGE_URI } from 'app/utils/Paths';
 import { findAttachmentByIdFromReasons, removeAttachmentFromReasons } from 'app/utils/appeal/extra.data';
 import { Navigation } from 'app/utils/navigation/navigation';
+import {CommonVariablesMiddleware} from "app/middleware/CommonVariablesMiddleware";
 
 const template = 'evidence-removal';
 
@@ -90,7 +91,8 @@ class Processor implements FormActionProcessor {
 }
 
 // tslint:disable-next-line: max-classes-per-file
-@controller(EVIDENCE_REMOVAL_PAGE_URI, SessionMiddleware, AuthMiddleware, CompanyAuthMiddleware)
+@controller(EVIDENCE_REMOVAL_PAGE_URI, SessionMiddleware, AuthMiddleware, CompanyAuthMiddleware,
+    CommonVariablesMiddleware)
 export class EvidenceRemovalController extends BaseController<Attachment> {
     constructor() {
         super(template, navigation, new FormValidator(schema), undefined,

--- a/src/controllers/EvidenceRemovalController.ts
+++ b/src/controllers/EvidenceRemovalController.ts
@@ -9,6 +9,7 @@ import { BaseController } from './BaseController';
 import { FormActionProcessor } from 'app/controllers/processors/FormActionProcessor';
 import { FormValidator } from 'app/controllers/validators/FormValidator';
 import { AuthMiddleware } from 'app/middleware/AuthMiddleware';
+import { CommonVariablesMiddleware } from 'app/middleware/CommonVariablesMiddleware';
 import { CompanyAuthMiddleware } from 'app/middleware/CompanyAuthMiddleware';
 import { Appeal } from 'app/models/Appeal';
 import { ApplicationData, APPLICATION_DATA_KEY } from 'app/models/ApplicationData';
@@ -19,7 +20,6 @@ import { FileTransferService } from 'app/modules/file-transfer-service/FileTrans
 import { EVIDENCE_REMOVAL_PAGE_URI, EVIDENCE_UPLOAD_PAGE_URI, SIGNOUT_PAGE_URI } from 'app/utils/Paths';
 import { findAttachmentByIdFromReasons, removeAttachmentFromReasons } from 'app/utils/appeal/extra.data';
 import { Navigation } from 'app/utils/navigation/navigation';
-import {CommonVariablesMiddleware} from "app/middleware/CommonVariablesMiddleware";
 
 const template = 'evidence-removal';
 


### PR DESCRIPTION
### JIRA link

[BI-11766
](https://companieshouse.atlassian.net/browse/BI-11766)


### Change description

Add `CommonVariablesMiddleware` to `EvidenceRemovalController` to allow the user email to be set on the remove document page.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
