### PR TITLE
BI-8932 Remove 'Upload document' button

### DIFF
--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -125,5 +125,5 @@
       </form>
     </div>
   </div>
-  <script src="//{{ cdn.host }}/javascripts/app/lfp-appeals/upload.js"></script>
+  <script src="//{{ cdn.host }}/javascripts/app/late-filing-penalties/appeals/upload.js"></script>
 {% endblock %}

--- a/src/views/evidence-upload.njk
+++ b/src/views/evidence-upload.njk
@@ -61,7 +61,7 @@
         <li>photographs</li>
       </ul>
 
-      <form method="post" enctype="multipart/form-data" action="{{ navigation.actions.uploadFile }}">
+      <form id="upload-form" method="post" enctype="multipart/form-data" action="{{ navigation.actions.uploadFile }}">
         {% set uploadText %}
           Upload a document
         {% endset %}
@@ -80,16 +80,18 @@
               }
             })
           }}
-          {{
-            govukButton({
-              text: 'Upload document',
-              classes: 'govuk-button--secondary',
-              id: 'add-document',
-              attributes: {
-                'data-event-id': 'clicked add document'
-              }
-            })
-          }}
+          <noscript>
+            {{
+              govukButton({
+                text: 'Upload document',
+                classes: 'govuk-button--secondary',
+                id: 'add-document',
+                attributes: {
+                  'data-event-id': 'clicked add document'
+                }
+              })
+            }}
+          </noscript>
         </div>
       </form>
 
@@ -123,4 +125,5 @@
       </form>
     </div>
   </div>
+  <script src="//{{ cdn.host }}/javascripts/app/lfp-appeals/upload.js"></script>
 {% endblock %}


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/BI-8932

### Change description
When uploading evidence, instead of the user having to click a button after selecting the file, the file is now uploaded automatically after selection.

### Work checklist

- [ ] Tests added where applicable
- [ ] UI changes look good on mobile
- [ ] UI changes meet accessibility criteria

### Merge instructions

We are committed to keeping commit history clean, consistent and linear. To achieve this commit should be structured as follows:

```
<type>[optional scope]: <description>
```

and contain the following structural elements:

- fix: a commit that patches a bug in your codebase (this correlates with PATCH in semantic versioning),
- feat: a commit that introduces a new feature to the codebase (this correlates with MINOR in semantic versioning),
- BREAKING CHANGE: a commit that has a footer `BREAKING CHANGE:` introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of commits of any type,
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others,
- footers other than `BREAKING CHANGE: <description>` may be provided.
