### PR TITLE
fix the terraform sources to use correct uris

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules/aws/ecs/secrets?ref=1.0.191"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.192"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git::git@github.com:companieshouse/terraform-library-ecs-service.git?ref=1.0.2"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.192"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
This pr fixes the uris used to pull code from the terraform resources repo. This is to match the source for the confirmation statement web and fix the cidev-plan build in concourse.
