### PR TITLE
Remove cdn host from secrets

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -16,7 +16,6 @@ locals {
     "vpc_name"              = local.service_secrets["vpc_name"]
     "chs_api_key"           = local.service_secrets["chs_api_key"]
     "internal_api_url"      = local.service_secrets["internal_api_url"]
-    "cdn_host"              = local.service_secrets["cdn_host"]
     "oauth2_auth_uri"       = local.service_secrets["oauth2_auth_uri"]
     "oauth2_redirect_uri"   = local.service_secrets["oauth2_redirect_uri"]
     "account_test_url"      = local.service_secrets["account_test_url"]


### PR DESCRIPTION
This pr removes the cdn_host from the list of variables read from the vault as this is held in the vars file.